### PR TITLE
feat: add experimental asset serving pipeline for images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 *.zip
 *.gz
 
+# Ignore data directory
+assets/
+
 # Benchmark
 *.pprof
 

--- a/cmd/kektordb/main.go
+++ b/cmd/kektordb/main.go
@@ -3,10 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/sanonone/kektordb/internal/server"
-	"github.com/sanonone/kektordb/pkg/embeddings"
-	"github.com/sanonone/kektordb/pkg/engine"
-	"github.com/sanonone/kektordb/pkg/proxy"
 	"log"
 	"log/slog"
 	"net/http"
@@ -17,6 +13,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/sanonone/kektordb/internal/server"
+	"github.com/sanonone/kektordb/pkg/embeddings"
+	"github.com/sanonone/kektordb/pkg/engine"
+	"github.com/sanonone/kektordb/pkg/proxy"
 )
 
 // getEnv retrieves an environment variable or returns a default value.
@@ -79,10 +80,10 @@ func main() {
 
 	// Flags proxy
 	enableProxy := flag.Bool("enable-proxy", false, "Enable the AI Semantic Proxy")
-	//proxyPort := flag.String("proxy-port", ":9092", "Port for the AI Semantic Proxy")
-	//proxyTarget := flag.String("proxy-target", "http://localhost:11434", "Target LLM URL (e.g. Ollama)")
-	//firewallIndex := flag.String("firewall-index", "prompt_guard", "Index containing forbidden prompts")
-	//proxyConfigPath := flag.String("proxy-config", "", "Path to proxy.yaml config file")
+	// proxyPort := flag.String("proxy-port", ":9092", "Port for the AI Semantic Proxy")
+	// proxyTarget := flag.String("proxy-target", "http://localhost:11434", "Target LLM URL (e.g. Ollama)")
+	// firewallIndex := flag.String("firewall-index", "prompt_guard", "Index containing forbidden prompts")
+	// proxyConfigPath := flag.String("proxy-config", "", "Path to proxy.yaml config file")
 	proxyConfigPath := flag.String("proxy-config", "", "Path to proxy.yaml config file")
 
 	flag.Parse()
@@ -114,7 +115,7 @@ func main() {
 		}
 	}
 
-	//log.Printf("Initializing Engine (Data: %s, Save: %v/%d ops)...", dataDir, opts.AutoSaveInterval, opts.AutoSaveThreshold)
+	// log.Printf("Initializing Engine (Data: %s, Save: %v/%d ops)...", dataDir, opts.AutoSaveInterval, opts.AutoSaveThreshold)
 
 	// Engine Startup
 	eng, err := engine.Open(opts)
@@ -123,7 +124,7 @@ func main() {
 	}
 
 	// Starting HTTP Server
-	srv, err := server.NewServer(eng, *httpAddr, *vectorizersConfig, *authToken)
+	srv, err := server.NewServer(eng, *httpAddr, *vectorizersConfig, *authToken, dataDir)
 	if err != nil {
 		slog.Error("Failed to create server", "error", err)
 		eng.Close()

--- a/docs/design/001-hybrid-storage-architecture-rfc.md
+++ b/docs/design/001-hybrid-storage-architecture-rfc.md
@@ -1,0 +1,160 @@
+# RFC 001: KektorDB Hybrid Storage Architecture
+
+**Status:** Draft / Planned for v0.5.0 **Date:** 2025-12-25 **Context:** Scalability beyond RAM limits while preserving a simple architecture.
+
+## 1. Executive Summary
+
+Currently, KektorDB is a **pure in-memory** database. Both vectors and the HNSW graph reside entirely in the Go heap. This guarantees extremely low latency but limits the dataset size to the available physical RAM.
+
+This RFC proposes introducing a **pluggable storage architecture** that allows choosing, **per index**, whether data is kept in RAM (speed priority) or on disk (scalability priority), adopting a pragmatic **hybrid approach** (graph in RAM, vectors on disk).
+
+---
+
+## 2. Core Design Decisions
+
+### 2.1 Hybrid Architecture (Hybrid DiskStore)
+
+Instead of moving everything to disk (as in DiskANN, which is complex), we adopt a pragmatic hybrid approach:
+
+1. **Structure (RAM):** The HNSW graph (node links) and, optionally, compressed vectors (`int8`) remain in RAM. This ensures the *navigation* phase is as fast as the in-memory version.
+2. **Data (Disk):** The original vectors (`float32`) are written to a binary file on disk and read only when needed (re-ranking phase or data retrieval).
+
+### 2.2 Standard I/O vs mmap
+
+We choose **standard I/O (**`** with **`**)** instead of memory mapping (`mmap`).
+
+> **Rationale:**
+>
+> 1. **Windows stability:** `mmap` on Windows has well-known file-locking issues that prevent critical operations such as resizing or file rotation without complex handle-management logic.
+> 2. **Predictability:** With standard I/O, the database has explicit control over when reads occur. With `mmap`, the kernel decides when to swap pages, potentially causing unpredictable latency spikes (page faults) that are hard to debug in Go.
+> 3. **Portability:** Using `os.File` is guaranteed to work on any architecture (ARM, x86, WASM) and any OS supported by Go, without platform-specific or `unsafe` code.
+
+### 2.3 Per-Index Granularity
+
+The `storage_type` configuration is applied at index creation time (`VCreate`). This enables mixed scenarios:
+
+- `hot_index`: In-memory for frequently accessed data.
+- `archive_index`: On-disk for large historical datasets.
+
+---
+
+## 3. Technical Implementation Plan
+
+### Phase 1: Abstraction (Refactoring)
+
+The goal is to decouple HNSW logic from vector storage details.
+
+**Action:** Introduce the `VectorProvider` interface.
+
+```go
+// pkg/core/storage/types.go
+
+// VectorProvider defines how vectors are stored and retrieved.
+type VectorProvider interface {
+    // Set stores a vector for a given internal ID.
+    Set(id uint32, vector []float32) error
+    
+    // Get retrieves a vector by internal ID.
+    // NOTE: Implementation should make this thread-safe.
+    Get(id uint32) ([]float32, error)
+    
+    // Size returns the number of vectors stored.
+    Size() uint32
+    
+    // Close cleans up resources (e.g., closes file handles).
+    Close() error
+}
+```
+
+**Impact on ****\`\`****:** The `Node` structure will no longer contain `VectorF32`. It will only contain links. The `hnsw.Index` will hold a reference to the `VectorProvider` to compute distances.
+
+### Phase 2: Memory Implementation
+
+Implement the interface while preserving current behavior.
+
+**Action:** Create `MemoryStore`.
+
+```go
+type MemoryStore struct {
+    vectors [][]float32 // Simple slice of slices, as today
+    mu      sync.RWMutex
+}
+```
+
+This step validates that the abstraction works without performance regressions before touching disk storage.
+
+### Phase 3: Disk Implementation
+
+Implement binary file–based storage.
+
+**Action:** Create `DiskStore`.
+
+- **File format:** Flat binary.
+  - Optional header: version, dimension (`uint32`).
+  - Body: contiguous sequence of `float32` values.
+- **Addressing:**
+  - Byte offset for ID `i` = `HeaderSize + (i * Dimension * 4 bytes)`.
+- **Reads:** Use `file.ReadAt` for concurrent reads without locking the file descriptor.
+
+### Phase 4: Integration & Re-ranking
+
+Modify the HNSW search algorithm to support re-ranking.
+
+**Logic:**
+
+1. **Search (RAM):** If the index uses `int8`, HNSW navigates using compressed vectors resident in RAM (inside the `Node`).
+2. **Refine (Disk):** If the index is disk-based, after search completion, fetch the original vectors from `DiskStore` for the top-K candidates and recompute exact scores.
+
+---
+
+## 4. Configuration Changes
+
+### `vectorizers.yaml`
+
+```yaml
+vectorizers:
+  - name: "huge_docs"
+    # ...
+    index_config:
+      metric: "cosine"
+      precision: "int8" # Recommended for Hybrid: lightweight graph in RAM
+      
+      # NEW FIELD
+      storage_type: "disk" # Options: "memory" (default), "disk"
+```
+
+### API `VCreate`
+
+The API endpoint `POST /vector/indexes` will accept a new JSON field: `"storage_type"`.
+
+---
+
+## 5. Persistence Strategy (Critical)
+
+How does this interact with AOF and snapshots?
+
+- **MemoryStore:**
+  - **Snapshot:** Serialize everything into the `.kdb` file (as today).
+- **DiskStore:**
+  - **Live:** Vectors are written immediately to the `.bin` file (append or write-at).
+  - **Snapshot:** The `.kdb` file stores **only the graph and metadata**. Vectors are not duplicated.
+  - **Restore:** On restart, KektorDB loads the graph into RAM from `.kdb` and opens a handle to the existing `.bin` file. *Startup time is drastically reduced.*
+
+---
+
+## 6. Migration Path
+
+No automatic in-place migration is planned. To move from `memory` to `disk`:
+
+1. Create a new index with `storage_type: "disk"`.
+2. Use a migration pipeline (read from old index → write to new index) or re-ingest data.
+
+---
+
+## 7. Known Limitations
+
+1. **I/O latency:** Disk access (even SSD) is orders of magnitude slower than RAM. Without `int8` vectors in RAM for navigation, performance will collapse. *Mitigation: hybrid mode is mandatory or strongly recommended.*
+2. **Backups:** Backups now require copying two files (`.kdb` and `.bin`) instead of one.
+
+---
+

--- a/docs/design/002-vision-pipeline-rfc.md
+++ b/docs/design/002-vision-pipeline-rfc.md
@@ -1,0 +1,90 @@
+# RFC 002: Multimodal Vision Pipeline Limitations & Future Plan
+**Status:** Draft / Post-v0.4.0 Analysis
+**Context:** Current implementation of PDF image extraction and semantic indexing.
+
+## 1. Executive Summary
+With release v0.4.0, KektorDB introduces a multimodal "Vision" pipeline that extracts images from PDFs, generates textual descriptions via LLM (e.g., Llama 3.2 Vision), and indexes them as searchable vectors.
+While functional, the current implementation sacrifices **positional precision** for **architectural simplicity** (avoiding complex CGO dependencies).
+
+This document analyzes the limitations of the current approach and proposes a technical roadmap to resolve them in future versions.
+
+---
+
+## 2. Current Architecture & Flow
+
+### 2.1 The Extraction Process
+1.  **Text Extraction:** Uses `ledongthuc/pdf` to extract all text into a continuous string.
+2.  **Image Extraction:** Uses `pdfcpu` to extract all image objects into a temporary directory (and then persists them to `assets/`).
+3.  **Vision Analysis:** Each image is sent to the LLM, which generates a description.
+4.  **Injection:** Descriptions (and Markdown links to images) are **appended to the end** of the full document text.
+5.  **Chunking:** The text (Document + Appended Descriptions) is split into chunks.
+
+---
+
+## 3. Known Limitations (Technical Debt)
+
+### 3.1 Loss of Spatial Context (The "Appendix" Problem)
+**Issue:** All images are moved to the end of the document ("Append-Only").
+*   *Example:* If a PDF has `Text A` -> `Image A` -> `Text B`, in KektorDB it becomes `Text A` -> `Text B` -> `Description Image A`.
+**Consequence:** The `prev/next` graph links connect the image to the last paragraph of the document, not to the paragraph that introduced it. This reduces RAG context quality if the image is crucial for understanding adjacent text.
+
+### 3.2 "Vector vs Raster" Blindness
+**Issue:** `pdfcpu` extracts only raster images (bitmaps: JPG, PNG). Many technical PDFs (e.g., datasheets, scientific papers) use vector graphics (SVG/PDF draw commands).
+**Consequence:** These charts are completely ignored by the Vision pipeline. The text inside them is extracted (often in a disorganized way), but the visual "shape" is lost.
+
+### 3.3 LLM Dependency for Rendering
+**Issue:** The injection of the image into the final chat (`![img](url)`) relies on the LLM deciding to copy the Markdown tag into its output.
+**Consequence:** With small models (< 7B) or those not well-instructed, the tag is often lost or transformed into plain text, making the image invisible to the end user.
+
+---
+
+## 4. Proposed Solutions (Future Implementation Plan)
+
+### 4.1 Solution: Placeholder Injection (Context Fix)
+*Goal: Restore correct image positioning in the text flow.*
+
+**Technical Strategy:**
+Instead of extracting text and images in two separate, blind passes, we must use a parser that returns an ordered list of mixed elements.
+
+1.  **Low-Level Parsing:** Stop using `ledongthuc/pdf` (high-level text) and go down to the layout level.
+2.  **Token Stream:** Build a token stream that includes `TOKEN_TEXT` and `TOKEN_IMAGE_REF`.
+    *   *Stream:* `[Text: "Here is the chart:"]`, `[ImageRef: img_123.jpg]`, `[Text: "As you can see..."]`.
+3.  **Inline Replacement:** During the Vision Pipeline, replace `[ImageRef]` with the generated description and Markdown link, preserving position.
+
+**Challenge:** Requires a much more advanced Go PDF library (e.g., `unidoc` - beware of license, or a forked `rsc/pdf`) capable of providing Y-coordinates of objects on the page.
+
+### 4.2 Solution: Page-to-Image Rendering (Vector Fix)
+*Goal: Capture vector graphics and complex tables.*
+
+**Technical Strategy:**
+Instead of extracting image objects, render the entire PDF page as an image (screenshot).
+
+1.  **Rendering:** Convert `page_1.pdf` -> `page_1.png`.
+2.  **Vision:** Send the entire page to the LLM.
+3.  **Prompt:** *"Extract the text and describe the charts present on this page."*
+
+**Challenge (Critical):** There are no performant **Pure Go** libraries to render PDFs to images. It requires `CGO` with `libpoppler` or `mupdf`. This breaks the portability of the static binary (cross-compilation becomes a nightmare).
+*Decision:* This path should only be taken if we accept having separate/complex builds or an optional sidecar service.
+
+### 4.3 Solution: Proxy-Side Injection (UI Reliability Fix)
+*Goal: Ensure the image always appears in the chat, regardless of LLM intelligence.*
+
+**Technical Strategy:**
+Move the visualization responsibility from the LLM to the Proxy.
+
+1.  **Metadata Flag:** When the DB returns a chunk that is an "Image Description", the Proxy flags it.
+2.  **Stream Interception:** The Proxy forwards the LLM response to the user.
+3.  **Append:** Once the LLM stream is finished, the Proxy forcibly appends an extra Markdown block: `\n\n**Reference:** ![img](url)`.
+
+**Challenge:** Requires managing the HTTP stream (SSE) in the proxy to inject extra data packets at the end. Feasible but delicate.
+
+---
+
+## 5. Recommendation for v0.5
+
+It is recommended to prioritize **Solution 4.3 (Proxy-Side Injection)** because:
+1.  It solves the most visible problem (missing images).
+2.  It is pure Go code in the Proxy, with no external dependencies.
+3.  It improves UX immediately.
+
+The positional problem (4.1) is acceptable for now, as the semantic graph (`mentions`) mitigates the loss of sequentiality.

--- a/internal/server/vectorizer_service.go
+++ b/internal/server/vectorizer_service.go
@@ -19,7 +19,7 @@ type VectorizerService struct {
 }
 
 // NewVectorizerService initializes the service based on the YAML config.
-func NewVectorizerService(server *Server) (*VectorizerService, error) {
+func NewVectorizerService(server *Server, assetsDir string) (*VectorizerService, error) {
 	service := &VectorizerService{
 		server: server,
 	}
@@ -96,6 +96,8 @@ func NewVectorizerService(server *Server) (*VectorizerService, error) {
 			GraphEntityExtraction: cfg.GraphEntityExtraction,
 			LLMConfig:             cfg.LLM,
 			VisionLLMConfig:       cfg.VisionLLM,
+
+			AssetsOutputDir: assetsDir,
 
 			IndexMetric:         idxMetric,
 			IndexPrecision:      idxPrec,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -502,6 +502,8 @@ func (p *AIProxy) performRAGInjection(originalBody []byte, queryVec []float32, q
 			continue
 		}
 
+		mainText = strings.ReplaceAll(mainText, "](/assets/", "](http://localhost:9091/assets/")
+
 		prevText := ""
 		if prevNodes, ok := res.Node.Connections["prev"]; ok && len(prevNodes) > 0 {
 			prevText = getTextFromMeta(prevNodes[0].VectorData.Metadata)
@@ -549,6 +551,11 @@ func (p *AIProxy) performRAGInjection(originalBody []byte, queryVec []float32, q
 		}
 		contextBuilder.WriteString("\n\n")
 		foundRelevant = true
+
+		// Debug
+		if strings.Contains(mainText, "![") {
+			slog.Info("[DEBUG IMAGE] Found image tag in chunk: %s", mainText)
+		}
 	}
 
 	if !foundRelevant {

--- a/pkg/rag/config.go
+++ b/pkg/rag/config.go
@@ -1,8 +1,9 @@
 package rag
 
 import (
-	"github.com/sanonone/kektordb/pkg/llm"
 	"time"
+
+	"github.com/sanonone/kektordb/pkg/llm"
 )
 
 // Config holds all parameters to set up a RAG pipeline.
@@ -43,6 +44,8 @@ type Config struct {
 	EntityExtractionPrompt string
 
 	VisionLLMConfig llm.Config
+
+	AssetsOutputDir string
 
 	IndexMetric         string
 	IndexPrecision      string

--- a/pkg/rag/loader.go
+++ b/pkg/rag/loader.go
@@ -4,10 +4,11 @@ package rag
 
 // Image represents a visual asset extracted from a document.
 type Image struct {
-	Data []byte // Raw binary data
-	Ext  string // e.g., "png", "jpg"
-	Name string // Filename (e.g. "im1-3.png"), useful for sorting
-	Page int    // Page number where it was found
+	ID      string
+	Data    []byte // Raw binary data
+	Ext     string // e.g., "png", "jpg"
+	Page    int    // Page number where it was found
+	URLPath string // e.g. /assets/image_24892.png
 }
 
 // Document represents the extracted content of a file.

--- a/pkg/rag/loader_auto.go
+++ b/pkg/rag/loader_auto.go
@@ -12,10 +12,10 @@ type AutoLoader struct {
 	docxLoader Loader
 }
 
-func NewAutoLoader(extractImages bool) *AutoLoader {
+func NewAutoLoader(extractImages bool, assetsDir string) *AutoLoader {
 	return &AutoLoader{
 		textLoader: NewTextLoader(),
-		pdfLoader:  NewPDFAdvancedLoader(extractImages),
+		pdfLoader:  NewPDFAdvancedLoader(extractImages, assetsDir),
 		docxLoader: NewDocxLoader(),
 	}
 }

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -49,3 +49,26 @@ fast_llm:
 llm:
   base_url: "http://localhost:11434/v1"
   model: "gemma3:4b"
+
+rag_system_prompt: |
+  Sei un assistente tecnico esperto.
+  Il tuo compito è rispondere alla domanda dell'utente usando ESCLUSIVAMENTE le informazioni fornite nel contesto sottostante.
+  
+  LINEE GUIDA:
+  1. Sii DETTAGLIATO ed ESAUSTIVO.
+  2. CITAZIONI: Usa [Fonte: nomefile].
+  3. LINGUA: Rispondi nella stessa lingua della domanda.
+  
+   REGOLE RIGIDE:
+  1. Se nel testo vedi un link immagine che inizia con http://.../assets/..., devi mostrarlo.
+  2. Per mostrarlo, usa ESATTAMENTE questa sintassi Markdown col punto esclamativo davanti:
+     ![Diagramma](http://...il-tuo-url...)
+  3. Non usare mai la sintassi [Testo](Link) per le immagini, usa sempre ![Testo](Link).
+     
+  Se il contesto non contiene la risposta, dì chiaramente: "Non ho informazioni sufficienti nei documenti".
+
+  Contesto:
+  {{context}}
+
+  Domanda:
+  {{query}}


### PR DESCRIPTION
- Implemented HTTP file server in 'server.go' to serve extracted assets at '/assets/'.
- Updated PDF loader to extract images via 'pdfcpu', hash them for deduplication, and save them to disk.
- Enhanced Proxy to inject Markdown image links into the LLM context.
- Note: This feature is functional but dependent on the LLM's ability to preserve Markdown image tags in the final response. Small models may strip the tags.