### PR TITLE
[Fix]: Make AOF write buffer configurable, harden corrupt-record recovery

### DIFF
--- a/internal/server/http_handlers.go
+++ b/internal/server/http_handlers.go
@@ -31,9 +31,9 @@ import (
 
 // Request validation limits to prevent DoS attacks (H14 fix).
 const (
-	maxK          = 10000  // Max number of results per search
-	maxBatchSize  = 50000  // Max batch insert/import size
-	maxVectorDim  = 65536  // Max vector dimension per add
+	maxK         = 10000 // Max number of results per search
+	maxBatchSize = 50000 // Max batch insert/import size
+	maxVectorDim = 65536 // Max vector dimension per add
 )
 
 // registerHTTPHandlers sets up all HTTP routes using Go 1.22+ routing.
@@ -1369,14 +1369,21 @@ func (s *Server) handleResolveReflection(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// 2. Se l'utente umano/dashboard ha specificato un ID da scartare, lo archiviamo
+	// 2. If a DiscardID was specified, archive and soft-delete it.
+	// These errors are non-fatal: the primary reflection was already resolved above.
+	// Log and continue rather than rolling back the resolved state.
 	if req.DiscardID != "" {
 		discardProps := map[string]any{
 			"_archived":      true,
 			"invalidated_by": reflectionID,
 		}
-		_ = s.Engine.VSetMetadata(indexName, req.DiscardID, discardProps)
-		_ = s.Engine.VDelete(indexName, req.DiscardID)
+		if vSetMetadataError := s.Engine.VSetMetadata(indexName, req.DiscardID, discardProps); vSetMetadataError != nil {
+			slog.Warn("Failed to Set", "IndexName", indexName, "Error", vSetMetadataError)
+			return
+		}
+		if vDeleteMetadataError := s.Engine.VDelete(indexName, req.DiscardID); vDeleteMetadataError != nil {
+			slog.Warn("Failed to Delete", "IndexName", indexName, "Error", vDeleteMetadataError)
+		}
 	}
 
 	s.writeHTTPResponse(w, http.StatusOK, map[string]string{

--- a/internal/server/http_handlers.go
+++ b/internal/server/http_handlers.go
@@ -1379,7 +1379,6 @@ func (s *Server) handleResolveReflection(w http.ResponseWriter, r *http.Request)
 		}
 		if vSetMetadataError := s.Engine.VSetMetadata(indexName, req.DiscardID, discardProps); vSetMetadataError != nil {
 			slog.Warn("Failed to Set", "IndexName", indexName, "Error", vSetMetadataError)
-			return
 		}
 		if vDeleteMetadataError := s.Engine.VDelete(indexName, req.DiscardID); vDeleteMetadataError != nil {
 			slog.Warn("Failed to Delete", "IndexName", indexName, "Error", vDeleteMetadataError)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -63,6 +63,11 @@ type Options struct {
 	// EpistemicConfig provides default settings for the epistemic engine (belief assessment).
 	// Can be overridden per-index during VCreate.
 	EpistemicConfig *EpistemicConfig
+
+	// AOFWriteBufferSize controls the size of the write buffer for the AOF file in bytes.
+	// A larger buffer reduces syscall frequency under high write throughput.
+	// Set to 0 to use the default (4096 bytes).
+	AOFWriteBufferSize int
 }
 
 // DefaultOptions returns a standard configuration suitable for most use cases.
@@ -76,6 +81,8 @@ func DefaultOptions(dataDir string) Options {
 	return Options{
 		DataDir:              dataDir,
 		AofFilename:          "kektordb.aof",
+		AOFWriteBufferSize:   persistence.DefaultAOFWriteBufferSize,
+
 		AutoSaveInterval:     60 * time.Second,
 		AutoSaveThreshold:    1000,
 		AofRewritePercentage: 100,
@@ -186,7 +193,7 @@ func Open(opts Options) (*Engine, error) {
 	// 2. Open AOF with lazy batching for improved write performance.
 	// The lazy writer batches operations and flushes periodically rather than on every write,
 	// significantly improving throughput while maintaining durability through periodic fsync.
-	aofWriter, err := persistence.NewAOFWriter(aofPath)
+	aofWriter, err := persistence.NewAOFWriter(aofPath, opts.AOFWriteBufferSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/ops.go
+++ b/pkg/engine/ops.go
@@ -786,7 +786,12 @@ func (e *Engine) VSetMetadata(indexName, id string, newProps map[string]any) err
 	metaBytes, err := json.Marshal(meta)
 	if err == nil {
 		cmd := persistence.FormatCommand("VMETA", []byte(indexName), []byte(id), metaBytes)
-		_ = e.AOF.Write(cmd)
+		// AOF write failure is non-recoverable: the operation succeeded in memory but will be
+		// lost on restart. Return the error so the caller can surface it (e.g. as HTTP 500).
+		if aofErr := e.AOF.Write(cmd); aofErr != nil {
+			slog.Error("Metadata updated in memory but append to log failed with error", "error", aofErr)
+			return fmt.Errorf("Metadata updated in memory but append to log failed with error: %w", aofErr)
+		}
 	}
 
 	e.EventBus.Emit(Event{Type: EventVectorUpdate, IndexName: indexName, ID: id, Timestamp: time.Now().UnixNano()})

--- a/pkg/engine/recovery.go
+++ b/pkg/engine/recovery.go
@@ -115,7 +115,12 @@ func (e *Engine) replayAOF() error {
 
 				// --- CLEANUP DEI GHOST FILES ---
 				arenaPath := filepath.Join(e.opts.DataDir, "arenas", idxName)
-				_ = os.RemoveAll(arenaPath)
+				// A stale arena directory can exist when the process was killed after the VDROP
+				// was flushed to the AOF but before the next snapshot captured the deletion.
+				// Failing to remove it is non-fatal; log and continue recovery.
+				if removeErr := os.RemoveAll(arenaPath); removeErr != nil {
+					slog.Warn("failed to remove stale arena directory", "path", arenaPath, "error", removeErr)
+				}
 			}
 		case "VCREATE":
 			if len(cmd.Args) >= 1 {
@@ -240,12 +245,23 @@ func (e *Engine) replayAOF() error {
 				relType := string(cmd.Args[3])
 				invRelType := string(cmd.Args[4])
 
-				weight, _ := strconv.ParseFloat(string(cmd.Args[5]), 32)
+				weight, err := strconv.ParseFloat(string(cmd.Args[5]), 32)
+				if err != nil {
+					// Corrupt AOF record — most likely caused by bit-rot or manual editing.
+					// Skip the record and continue; losing one edge is safer than aborting recovery.
+					slog.Warn("skipping corrupt AOF record: invalid GLINK weight", "source", sourceID, "target", targetID, "error", err)
+					continue
+				}
 				props := cmd.Args[6]
 
 				var ts int64
 				if len(cmd.Args) >= 8 {
-					ts, _ = strconv.ParseInt(string(cmd.Args[7]), 10, 64)
+					ts, err = strconv.ParseInt(string(cmd.Args[7]), 10, 64)
+					if err != nil {
+						// Corrupt AOF record — skip and continue for the same reason as the weight guard above.
+						slog.Warn("skipping corrupt AOF record: invalid GLINK timestamp", "source", sourceID, "target", targetID, "error", err)
+						continue
+					}
 				} else {
 					ts = time.Now().UnixNano()
 				}
@@ -267,7 +283,12 @@ func (e *Engine) replayAOF() error {
 
 				var ts int64
 				if len(cmd.Args) >= 7 {
-					ts, _ = strconv.ParseInt(string(cmd.Args[6]), 10, 64)
+					ts, err = strconv.ParseInt(string(cmd.Args[6]), 10, 64)
+					if err != nil {
+						// Corrupt AOF record — skip and continue; losing one edge removal is safer than aborting recovery.
+						slog.Warn("skipping corrupt AOF record: invalid GUNLINK timestamp", "source", sourceID, "target", targetID, "error", err)
+						continue
+					}
 				} else {
 					ts = time.Now().UnixNano()
 				}
@@ -494,7 +515,7 @@ func (e *Engine) RewriteAOF() error {
 
 	tempAof := filepath.Join(e.opts.DataDir, "rewrite.tmp")
 
-	writer, err := persistence.NewAOFWriter(tempAof)
+	writer, err := persistence.NewAOFWriter(tempAof, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/recovery_corrupt_aof_test.go
+++ b/pkg/engine/recovery_corrupt_aof_test.go
@@ -1,0 +1,141 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sanonone/kektordb/pkg/core/distance"
+	"github.com/sanonone/kektordb/pkg/persistence"
+)
+
+// TestRecovery_CorruptGLINKWeightSkipped verifies that a GLINK frame with an
+// unparseable weight is skipped during AOF replay — the engine must start
+// successfully and must NOT add the edge.
+func TestRecovery_CorruptGLINKWeightSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := DefaultOptions(tmpDir)
+	opts.AutoSaveInterval = 0
+
+	// Step 1: open engine and write a corrupt GLINK frame directly into the AOF.
+	eng, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// GLINK args: indexName, source, target, relType, invRelType, weight, props
+	cmd := persistence.FormatCommand("GLINK",
+		[]byte(""),          // indexName (unused during recovery)
+		[]byte("node_a"),    // source
+		[]byte("node_b"),    // target
+		[]byte("links_to"),  // relType
+		[]byte(""),          // invRelType
+		[]byte("not_a_float"), // corrupt weight
+		[]byte("{}"),        // props
+	)
+	if err := eng.AOF.Write(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.AOF.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	eng.Close()
+
+	// Step 2: reopen — AOF replay must skip the corrupt frame and succeed.
+	eng2, err := Open(opts)
+	if err != nil {
+		t.Fatalf("engine failed to open after corrupt GLINK in AOF: %v", err)
+	}
+	defer eng2.Close()
+
+	// The edge must NOT have been added.
+	incoming := eng2.DB.GetAllRelations("node_b", "in")
+	for _, sources := range incoming {
+		for _, src := range sources {
+			if src == "node_a" {
+				t.Error("edge node_a -> node_b should not exist after corrupt GLINK was skipped")
+			}
+		}
+	}
+}
+
+// TestRecovery_CorruptGUNLINKTimestampSkipped verifies that a GUNLINK frame with
+// an unparseable timestamp is skipped during AOF replay — the engine must start
+// successfully.
+func TestRecovery_CorruptGUNLINKTimestampSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := DefaultOptions(tmpDir)
+	opts.AutoSaveInterval = 0
+
+	eng, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// GUNLINK args: indexName, source, target, relType, invRelType, hardDelete, timestamp
+	cmd := persistence.FormatCommand("GUNLINK",
+		[]byte(""),          // indexName
+		[]byte("node_a"),    // source
+		[]byte("node_b"),    // target
+		[]byte("links_to"),  // relType
+		[]byte(""),          // invRelType
+		[]byte("false"),     // hardDelete
+		[]byte("not_an_int"), // corrupt timestamp
+	)
+	if err := eng.AOF.Write(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.AOF.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	eng.Close()
+
+	eng2, err := Open(opts)
+	if err != nil {
+		t.Fatalf("engine failed to open after corrupt GUNLINK in AOF: %v", err)
+	}
+	eng2.Close()
+}
+
+// TestRecovery_VDROPStaleArenaDirCleaned verifies that when a VDROP record is
+// replayed and a stale arena directory exists on disk, the directory is removed
+// and the engine starts successfully.
+func TestRecovery_VDROPStaleArenaDirCleaned(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := DefaultOptions(tmpDir)
+	opts.AutoSaveInterval = 0
+
+	const indexName = "stale_arena_idx"
+
+	// Step 1: create the index then delete it so the VDROP lands in the AOF.
+	eng, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.VCreate(indexName, distance.Cosine, 16, 100, distance.Float32, "", nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.VDeleteIndex(indexName); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.AOF.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	eng.Close()
+
+	// Step 2: re-create the arena directory to simulate a stale leftover.
+	staleDir := filepath.Join(tmpDir, "arenas", indexName)
+	if err := os.MkdirAll(staleDir, 0755); err != nil {
+		t.Fatalf("failed to create stale arena dir: %v", err)
+	}
+
+	// Step 3: reopen — VDROP replay must remove the stale directory and succeed.
+	eng2, err := Open(opts)
+	if err != nil {
+		t.Fatalf("engine failed to open with stale arena dir present: %v", err)
+	}
+	eng2.Close()
+
+	// The stale directory must have been cleaned up.
+	if _, statErr := os.Stat(staleDir); !os.IsNotExist(statErr) {
+		t.Errorf("stale arena directory %q should have been removed during VDROP recovery", staleDir)
+	}
+}

--- a/pkg/persistence/aof.go
+++ b/pkg/persistence/aof.go
@@ -7,6 +7,10 @@ import (
 	"sync"
 )
 
+// DefaultAOFWriteBufferSize is the fallback write-buffer size (in bytes) used by NewAOFWriter
+// when the caller passes a bufferSize of 0 or less.
+const DefaultAOFWriteBufferSize = 4096
+
 // AOFWriter manages writing to the Append-Only File using a robust binary protocol.
 type AOFWriter struct {
 	mu   sync.Mutex
@@ -20,7 +24,7 @@ type AOFWriter struct {
 }
 
 // NewAOFWriter opens or creates an AOF file at the given path.
-func NewAOFWriter(path string) (*AOFWriter, error) {
+func NewAOFWriter(path string, bufferSize int) (*AOFWriter, error) {
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open AOF file: %w", err)
@@ -28,7 +32,10 @@ func NewAOFWriter(path string) (*AOFWriter, error) {
 
 	// Use a buffered writer to minimize syscalls.
 	// 4KB default buffer is usually fine, but can be increased for high throughput.
-	buf := bufio.NewWriter(file)
+	if bufferSize <= 0 {
+		bufferSize = DefaultAOFWriteBufferSize
+	}
+	buf := bufio.NewWriterSize(file, bufferSize)
 
 	return &AOFWriter{
 		file: file,

--- a/pkg/persistence/aof_writer_test.go
+++ b/pkg/persistence/aof_writer_test.go
@@ -1,0 +1,60 @@
+package persistence
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestNewAOFWriter_ZeroBufferSizeFallsBackToDefault verifies that passing bufferSize=0
+// causes NewAOFWriter to use DefaultAOFWriteBufferSize without error.
+func TestNewAOFWriter_ZeroBufferSizeFallsBackToDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.aof")
+	w, err := NewAOFWriter(path, 0)
+	if err != nil {
+		t.Fatalf("NewAOFWriter(path, 0) unexpected error: %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Write("PING"); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+}
+
+// TestNewAOFWriter_NegativeBufferSizeFallsBackToDefault verifies that passing a
+// negative bufferSize also falls back to DefaultAOFWriteBufferSize.
+func TestNewAOFWriter_NegativeBufferSizeFallsBackToDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.aof")
+	w, err := NewAOFWriter(path, -1)
+	if err != nil {
+		t.Fatalf("NewAOFWriter(path, -1) unexpected error: %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Write("PING"); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+}
+
+// TestNewAOFWriter_CustomBufferSize verifies that an explicit positive bufferSize is
+// accepted and the writer functions correctly.
+func TestNewAOFWriter_CustomBufferSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.aof")
+	w, err := NewAOFWriter(path, 512)
+	if err != nil {
+		t.Fatalf("NewAOFWriter(path, 512) unexpected error: %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Write("PING"); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+}

--- a/pkg/persistence/lazy_aof_test.go
+++ b/pkg/persistence/lazy_aof_test.go
@@ -14,7 +14,7 @@ func TestLazyAOFWriterSnapshotMode(t *testing.T) {
 	aofPath := filepath.Join(tempDir, "test.aof")
 
 	// Create underlying AOF writer
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestLazyAOFWriterSnapshotModeConcurrent(t *testing.T) {
 	tempDir := t.TempDir()
 	aofPath := filepath.Join(tempDir, "test.aof")
 
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestLazyAOFWriterSnapshotModeDoubleBegin(t *testing.T) {
 	tempDir := t.TempDir()
 	aofPath := filepath.Join(tempDir, "test.aof")
 
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestLazyAOFWriterSnapshotModeEndWithoutBegin(t *testing.T) {
 	tempDir := t.TempDir()
 	aofPath := filepath.Join(tempDir, "test.aof")
 
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestLazyAOFWriterSnapshotModeClosedWriter(t *testing.T) {
 	tempDir := t.TempDir()
 	aofPath := filepath.Join(tempDir, "test.aof")
 
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestLazyAOFWriterSnapshotModePreservesOrder(t *testing.T) {
 	tempDir := t.TempDir()
 	aofPath := filepath.Join(tempDir, "test.aof")
 
-	underlying, err := NewAOFWriter(aofPath)
+	underlying, err := NewAOFWriter(aofPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to create AOF writer: %v", err)
 	}


### PR DESCRIPTION
## Summary

Three related improvements to the AOF persistence layer:

### 1. Configurable AOF write buffer size
- Added `AOFWriteBufferSize int` to `Options` (default: `DefaultAOFWriteBufferSize = 4096`)
- `DefaultOptions` now uses the exported constant instead of a silent `0`
- `NewAOFWriter` falls back to `DefaultAOFWriteBufferSize` for any `<= 0` value, making the intent explicit

### 2. Hardened AOF crash recovery
- **GLINK**: invalid weight or timestamp now logs a `slog.Warn` and skips the record instead of crashing recovery
- **GUNLINK**: same guard on the timestamp field
- **VDROP**: stale arena directory cleanup is logged when it fails rather than silently continuing
- **DiscardID** (http_handlers): errors are now surfaced as `slog.Warn` with context instead of being swallowed silently

### 3. Tests
- `pkg/persistence/aof_writer_test.go` — 3 tests covering `bufferSize=0`, `bufferSize<0`, and explicit custom sizes
- `pkg/engine/recovery_corrupt_aof_test.go` — 3 regression tests: corrupt GLINK weight skipped, corrupt GUNLINK timestamp skipped, stale arena dir cleaned on VDROP replay