### PR TITLE
Feat/improve token lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/google/jsonschema-go v0.3.0
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
@@ -17,7 +17,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/tidwall/btree v1.8.1
 	github.com/x448/float16 v0.8.4
-	github.com/yosida95/uritemplate/v3 v3.0.2
 	golang.org/x/sys v0.43.0
 	gonum.org/v1/gonum v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -36,6 +35,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/hhrutter/lzw v1.0.0 // indirect
 	github.com/hhrutter/pkcs7 v0.2.0 // indirect
 	github.com/hhrutter/tiff v1.0.2 // indirect
@@ -51,6 +51,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/image v0.32.0 // indirect

--- a/internal/server/http_handlers.go
+++ b/internal/server/http_handlers.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sanonone/kektordb/internal/server/ui"
-	"github.com/sanonone/kektordb/pkg/auth"
 	"github.com/sanonone/kektordb/pkg/core"
 	"github.com/sanonone/kektordb/pkg/core/distance"
 	"github.com/sanonone/kektordb/pkg/core/hnsw"
@@ -2256,18 +2255,22 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(req.Namespaces) == 0 {
-		req.Namespaces = []string{"*"} // Default a tutti i namespace
+	if s.keyManager == nil {
+		s.writeHTTPError(w, http.StatusNotImplemented, fmt.Errorf("key management not available in OIDC mode"))
+		return
 	}
 
-	clearToken, policy, err := s.authService.GenerateKey(req.Description, req.Role, req.Namespaces)
+	if len(req.Namespaces) == 0 {
+		req.Namespaces = []string{"*"}
+	}
+
+	clearToken, policy, err := s.keyManager.GenerateKey(req.Description, req.Role, req.Namespaces)
 	if err != nil {
 		s.writeHTTPError(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	// Ritorniamo il token in chiaro SOLO in questo momento.
-	// Dopo questa risposta, non sarà mai più recuperabile.
+	// Return the token in clear ONLY at this moment. It is never stored and cannot be recovered.
 	s.writeHTTPResponse(w, http.StatusOK, map[string]any{
 		"token":   clearToken,
 		"policy":  policy,
@@ -2276,32 +2279,56 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
-	// Questo richiede una scansione del KV store per le chiavi che iniziano con "_sys_auth::"
-	keys := s.Engine.DB.GetKVStore().GetKeysWithPrefix("_sys_auth::", 0)
-
-	var policies []*auth.APIKeyPolicy
-	for _, key := range keys {
-		if val, found := s.Engine.DB.GetKVStore().Get(key); found {
-			var policy auth.APIKeyPolicy
-			if err := json.Unmarshal(val, &policy); err == nil {
-				policies = append(policies, &policy)
-			}
-		}
+	// JWT tokens are self-contained and not stored server-side.
+	// Only revoked token IDs (jti denylist) are tracked in KV.
+	revokedKeys := s.Engine.DB.GetKVStore().GetKeysWithPrefix("_sys_auth::revoked::", 0)
+	jtis := make([]string, 0, len(revokedKeys))
+	for _, k := range revokedKeys {
+		jtis = append(jtis, strings.TrimPrefix(k, "_sys_auth::revoked::"))
 	}
-
-	s.writeHTTPResponse(w, http.StatusOK, policies)
+	s.writeHTTPResponse(w, http.StatusOK, map[string]any{
+		"revoked_token_ids": jtis,
+		"note":              "Active JWT tokens are self-contained and not listed server-side.",
+	})
 }
 
 func (s *Server) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
-	// L'ID nell'URL è in realtà l'hash (che si può recuperare da GET /auth/keys)
-	hashedKey := r.PathValue("id")
-	if hashedKey == "" {
-		s.writeHTTPError(w, http.StatusBadRequest, fmt.Errorf("key id missing"))
+	// The id in the URL is the jti (from the policy returned at key creation time).
+	jti := r.PathValue("id")
+	if jti == "" {
+		s.writeHTTPError(w, http.StatusBadRequest, fmt.Errorf("key id (jti) missing"))
 		return
 	}
 
-	s.authService.RevokeKey(hashedKey)
-	s.writeHTTPResponse(w, http.StatusOK, map[string]string{"status": "revoked"})
+	if s.keyManager == nil {
+		s.writeHTTPError(w, http.StatusNotImplemented, fmt.Errorf("key revocation not available in OIDC mode"))
+		return
+	}
+
+	if err := s.keyManager.RevokeKey(jti); err != nil {
+		s.writeHTTPError(w, http.StatusBadRequest, err)
+		return
+	}
+	s.writeHTTPResponse(w, http.StatusOK, map[string]string{"status": "revoked", "jti": jti})
+}
+
+// handleJWKS serves the public key as a JWKS document at /.well-known/jwks.json.
+// This endpoint is unauthenticated so gateways and external services can fetch
+// the public key and verify KektorDB JWTs locally without calling the server on
+// every request.
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if s.keyManager == nil {
+		s.writeHTTPError(w, http.StatusNotImplemented, fmt.Errorf("JWKS not available in OIDC mode; fetch from your IDP's /.well-known/openid-configuration"))
+		return
+	}
+	jwks, err := s.keyManager.PublicKeyJWKS()
+	if err != nil {
+		s.writeHTTPError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jwks) //nolint:errcheck
 }
 
 /*

--- a/internal/server/rbac_test.go
+++ b/internal/server/rbac_test.go
@@ -230,3 +230,87 @@ func TestRBACAndNamespaces(t *testing.T) {
 		}
 	})
 }
+
+func TestJWKSEndpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := engine.DefaultOptions(tmpDir)
+	opts.AutoSaveInterval = 0
+	eng, err := engine.Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	srv, err := NewServer(eng, ":0", "", "master", tmpDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The JWKS endpoint is registered on rootMux (unauthenticated).
+	// Reproduce that mux here to test the handler directly.
+	rootMux := http.NewServeMux()
+	rootMux.HandleFunc("GET /.well-known/jwks.json", srv.handleJWKS)
+
+	t.Run("Returns 200 with application/json content-type", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+		w := httptest.NewRecorder()
+		rootMux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		ct := w.Header().Get("Content-Type")
+		if ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+	})
+
+	t.Run("Returns valid JWKS with EC P-256 key", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+		w := httptest.NewRecorder()
+		rootMux.ServeHTTP(w, req)
+
+		var jwks struct {
+			Keys []map[string]string `json:"keys"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &jwks); err != nil {
+			t.Fatalf("invalid JWKS JSON: %v", err)
+		}
+		if len(jwks.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(jwks.Keys))
+		}
+		key := jwks.Keys[0]
+		for _, field := range []string{"kty", "crv", "use", "alg", "x", "y"} {
+			if key[field] == "" {
+				t.Errorf("JWKS missing field %q", field)
+			}
+		}
+		if key["kty"] != "EC" || key["crv"] != "P-256" || key["alg"] != "ES256" {
+			t.Errorf("unexpected key parameters: %v", key)
+		}
+	})
+
+	t.Run("Accessible without Authorization header", func(t *testing.T) {
+		// No token — must succeed because JWKS is on the unauthenticated rootMux.
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+		w := httptest.NewRecorder()
+		rootMux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("JWKS must be unauthenticated, got %d", w.Code)
+		}
+	})
+
+	t.Run("Same public key across two requests", func(t *testing.T) {
+		fetch := func() []byte {
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+			w := httptest.NewRecorder()
+			rootMux.ServeHTTP(w, req)
+			return w.Body.Bytes()
+		}
+		r1, r2 := fetch(), fetch()
+		if string(r1) != string(r2) {
+			t.Error("JWKS response changed between requests — key should be stable")
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,8 +26,9 @@ type Server struct {
 	vectorizerService *VectorizerService
 
 	// Auth
-	authToken   string            // Master Root Token
-	authService *auth.AuthService // RBAC Manager
+	authToken   string           // Master Root Token
+	authService auth.TokenVerifier // Verifies tokens (JWT or OIDC)
+	keyManager  auth.KeyManager    // Issues and revokes keys (JWT only; nil in OIDC mode)
 
 	gardener *cognitive.Gardener
 }
@@ -50,12 +51,18 @@ func NewServer(eng *engine.Engine, httpAddr string, vectorizersConfigPath string
 		return nil, fmt.Errorf("failed to create assets dir: %w", err)
 	}
 
+	jwtProvider, err := auth.NewJWTProvider(eng.DB.GetKVStore())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize auth provider: %w", err)
+	}
+
 	s := &Server{
 		Engine:           eng,
 		taskManager:      NewTaskManager(),
 		vectorizerConfig: vecConfig,
 		authToken:        authToken,
-		authService:      auth.NewAuthService(eng.DB.GetKVStore()),
+		authService:      jwtProvider,
+		keyManager:       jwtProvider,
 	}
 
 	// Load cognitive engine config (from YAML or defaults)
@@ -108,6 +115,8 @@ func NewServer(eng *engine.Engine, httpAddr string, vectorizersConfigPath string
 
 	rootMux := http.NewServeMux()
 	rootMux.HandleFunc("GET /healthz", s.handleHealthz)
+	// JWKS is unauthenticated — clients and gateways fetch the public key to verify tokens locally.
+	rootMux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
 	rootMux.Handle("/", handler)
 	s.httpServer = &http.Server{
 		Addr:           httpAddr,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,7 @@ type Server struct {
 	vectorizerService *VectorizerService
 
 	// Auth
-	authToken   string           // Master Root Token
+	authToken   string             // Master Root Token
 	authService auth.TokenVerifier // Verifies tokens (JWT or OIDC)
 	keyManager  auth.KeyManager    // Issues and revokes keys (JWT only; nil in OIDC mode)
 

--- a/pkg/auth/interfaces.go
+++ b/pkg/auth/interfaces.go
@@ -1,0 +1,21 @@
+// Package auth provides Role-Based Access Control (RBAC) and API Key management for KektorDB.
+package auth
+
+// TokenVerifier is the only contract the middleware needs.
+type TokenVerifier interface {
+	VerifyToken(token string) (*APIKeyPolicy, error)
+}
+
+// KeyManager extends TokenVerifier for backends that own key lifecycle.
+type KeyManager interface {
+	TokenVerifier
+	GenerateKey(description, role string, namespaces []string) (string, *APIKeyPolicy, error)
+	RevokeKey(tokenID string) error
+	PublicKeyJWKS() ([]byte, error) // serves /.well-known/jwks.json
+}
+
+// Backend is what the Server holds. Mode tells you which path is active.
+type Backend struct {
+	Mode     string // JWT | OIC
+	Verifier TokenVerifier
+}

--- a/pkg/auth/jwt_provider.go
+++ b/pkg/auth/jwt_provider.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/sanonone/kektordb/pkg/core"
+)
+
+// KektorClaims are the JWT claims embedded in every token issued by JWTProvider.
+// RegisteredClaims provides sub, iat, nbf, exp, jti automatically.
+type KektorClaims struct {
+	jwt.RegisteredClaims
+	Role        string   `json:"role"`
+	Namespaces  []string `json:"namespaces"`
+	Description string   `json:"description"`
+}
+
+// JWTProvider container for Signer & KVStore to revoke & verify key
+type JWTProvider struct {
+	signer  *Signer
+	kvStore *core.KVStore
+}
+
+// NewJWTProvider returns an instance of JWTProvider
+func NewJWTProvider(kv *core.KVStore) (*JWTProvider, error) {
+	signer, err := loadOrCreateSigner(kv)
+	if err != nil {
+		return nil, err
+	}
+	return &JWTProvider{signer: signer, kvStore: kv}, nil
+}
+
+// GenerateKey mints a signed JWT with the given role and namespace constraints.
+// Returns the compact token string (given to the caller once, never stored)
+// and a policy struct for display purposes.
+func (j *JWTProvider) GenerateKey(description, role string, namespaces []string) (string, *APIKeyPolicy, error) {
+	if role != RoleAdmin && role != RoleWrite && role != RoleRead {
+		return "", nil, fmt.Errorf("invalid role: must be admin, write, or read")
+	}
+
+	now := time.Now()
+	jti := uuid.New().String()
+
+	claims := KektorClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(90 * 24 * time.Hour)),
+		},
+		Role:        role,
+		Namespaces:  namespaces,
+		Description: description,
+	}
+
+	tokenStr, err := j.signer.SignToken(claims)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	policy := &APIKeyPolicy{
+		ID:          jti,
+		Description: description,
+		Role:        role,
+		Namespaces:  namespaces,
+		CreatedAt:   now.Unix(),
+	}
+
+	return tokenStr, policy, nil
+}
+
+// PublicKeyJWKS returns the public key as a JWKS JSON document.
+// Serve this at GET /.well-known/jwks.json so clients can verify tokens
+// without calling KektorDB on every request.
+func (j *JWTProvider) PublicKeyJWKS() ([]byte, error) {
+	pub := j.signer.PublicKey()
+	if pub == nil {
+		return nil, fmt.Errorf("auth: signer has no public key")
+	}
+
+	// Convert to ecdh.PublicKey; .Bytes() returns uncompressed 04 || X || Y.
+	// For P-256 that is always exactly 1 + 32 + 32 = 65 bytes.
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf("auth: failed to convert public key to ECDH: %w", err)
+	}
+	raw := ecdhPub.Bytes() // [04, x0..x31, y0..y31]
+	x := raw[1:33]
+	y := raw[33:65]
+
+	jwks := map[string]any{
+		"keys": []map[string]string{
+			{
+				"kty": "EC",
+				"crv": "P-256",
+				"use": "sig",
+				"alg": "ES256",
+				"x":   base64.RawURLEncoding.EncodeToString(x),
+				"y":   base64.RawURLEncoding.EncodeToString(y),
+			},
+		},
+	}
+	return json.Marshal(jwks)
+}
+
+func (j *JWTProvider) VerifyToken(token string) (*APIKeyPolicy, error) {
+
+	const kvKey = "_sys_auth::ecdsa_private_key"
+}
+
+	// Hash the incoming token
+	hash := sha256.Sum256([]byte(clearToken))
+	hashedKey := hex.EncodeToString(hash[:])
+	storageKey := "_sys_auth::" + hashedKey
+
+	// Lookup in KV Store
+	policyBytes, found := s.kvStore.Get(storageKey)
+	if !found {
+		return nil, fmt.Errorf("invalid or revoked API key")
+	}
+
+	var policy APIKeyPolicy
+	if err := json.Unmarshal(policyBytes, &policy); err != nil {
+		return nil, fmt.Errorf("corrupted API key policy")
+	}
+
+	return &policy, nil

--- a/pkg/auth/jwt_provider.go
+++ b/pkg/auth/jwt_provider.go
@@ -108,25 +108,45 @@ func (j *JWTProvider) PublicKeyJWKS() ([]byte, error) {
 	return json.Marshal(jwks)
 }
 
-func (j *JWTProvider) VerifyToken(token string) (*APIKeyPolicy, error) {
+// VerifyToken parses and validates a JWT, checks the revocation denylist,
+// and maps the embedded KektorClaims into an APIKeyPolicy for the middleware.
+// exp/nbf/iat are validated automatically by jwt.ParseWithClaims.
+func (j *JWTProvider) VerifyToken(tokenStr string) (*APIKeyPolicy, error) {
+	parsed, err := jwt.ParseWithClaims(tokenStr, &KektorClaims{}, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("auth: unexpected signing method: %v", t.Header["alg"])
+		}
+		return j.signer.PublicKey(), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auth: invalid token: %w", err)
+	}
 
-	const kvKey = "_sys_auth::ecdsa_private_key"
+	claims, ok := parsed.Claims.(*KektorClaims)
+	if !ok || !parsed.Valid {
+		return nil, fmt.Errorf("auth: malformed token claims")
+	}
+
+	// Denylist check — only KV lookup on the hot path; absent for valid tokens.
+	if _, revoked := j.kvStore.Get("_sys_auth::revoked::" + claims.ID); revoked {
+		return nil, fmt.Errorf("auth: token has been revoked")
+	}
+
+	return &APIKeyPolicy{
+		ID:          claims.ID,
+		Description: claims.Description,
+		Role:        claims.Role,
+		Namespaces:  claims.Namespaces,
+		CreatedAt:   claims.IssuedAt.Unix(),
+	}, nil
 }
 
-	// Hash the incoming token
-	hash := sha256.Sum256([]byte(clearToken))
-	hashedKey := hex.EncodeToString(hash[:])
-	storageKey := "_sys_auth::" + hashedKey
-
-	// Lookup in KV Store
-	policyBytes, found := s.kvStore.Get(storageKey)
-	if !found {
-		return nil, fmt.Errorf("invalid or revoked API key")
+// RevokeKey adds a token's jti to the denylist. VerifyToken will reject it
+// on all subsequent requests regardless of its exp claim.
+func (j *JWTProvider) RevokeKey(jti string) error {
+	if jti == "" {
+		return fmt.Errorf("auth: jti must not be empty")
 	}
-
-	var policy APIKeyPolicy
-	if err := json.Unmarshal(policyBytes, &policy); err != nil {
-		return nil, fmt.Errorf("corrupted API key policy")
-	}
-
-	return &policy, nil
+	j.kvStore.Set("_sys_auth::revoked::"+jti, []byte("1"))
+	return nil
+}

--- a/pkg/auth/jwt_provider_test.go
+++ b/pkg/auth/jwt_provider_test.go
@@ -1,0 +1,286 @@
+package auth
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sanonone/kektordb/pkg/core"
+)
+
+// newTestProvider creates a JWTProvider backed by a fresh in-memory KV store.
+func newTestProvider(t *testing.T) *JWTProvider {
+	t.Helper()
+	kv := core.NewKVStore()
+	p, err := NewJWTProvider(kv)
+	if err != nil {
+		t.Fatalf("NewJWTProvider: %v", err)
+	}
+	return p
+}
+
+// --- GenerateKey ---
+
+func TestGenerateKey_ValidRoles(t *testing.T) {
+	p := newTestProvider(t)
+	for _, role := range []string{RoleAdmin, RoleWrite, RoleRead} {
+		token, policy, err := p.GenerateKey("test key", role, []string{"ns1"})
+		if err != nil {
+			t.Fatalf("role %s: unexpected error: %v", role, err)
+		}
+		if token == "" {
+			t.Fatalf("role %s: expected non-empty token", role)
+		}
+		// JWT compact form: three base64url segments separated by dots
+		parts := strings.Split(token, ".")
+		if len(parts) != 3 {
+			t.Fatalf("role %s: token does not look like a JWT (got %d parts)", role, len(parts))
+		}
+		if policy.Role != role {
+			t.Errorf("role %s: policy.Role = %q, want %q", role, policy.Role, role)
+		}
+		if policy.ID == "" {
+			t.Errorf("role %s: policy.ID (jti) is empty", role)
+		}
+	}
+}
+
+func TestGenerateKey_InvalidRole(t *testing.T) {
+	p := newTestProvider(t)
+	_, _, err := p.GenerateKey("bad", "superuser", []string{"*"})
+	if err == nil {
+		t.Fatal("expected error for invalid role, got nil")
+	}
+}
+
+func TestGenerateKey_DefaultNamespace(t *testing.T) {
+	p := newTestProvider(t)
+	_, policy, err := p.GenerateKey("key", RoleRead, []string{"my-index"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(policy.Namespaces) != 1 || policy.Namespaces[0] != "my-index" {
+		t.Errorf("unexpected namespaces: %v", policy.Namespaces)
+	}
+}
+
+// --- VerifyToken ---
+
+func TestVerifyToken_Valid(t *testing.T) {
+	p := newTestProvider(t)
+	token, policy, err := p.GenerateKey("valid key", RoleWrite, []string{"idx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.VerifyToken(token)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Role != RoleWrite {
+		t.Errorf("Role = %q, want %q", got.Role, RoleWrite)
+	}
+	if got.ID != policy.ID {
+		t.Errorf("ID = %q, want %q", got.ID, policy.ID)
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0] != "idx" {
+		t.Errorf("Namespaces = %v", got.Namespaces)
+	}
+}
+
+func TestVerifyToken_Tampered(t *testing.T) {
+	p := newTestProvider(t)
+	token, _, err := p.GenerateKey("key", RoleAdmin, []string{"*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Flip the last character of the signature to invalidate it.
+	tampered := token[:len(token)-1] + "X"
+	if _, err := p.VerifyToken(tampered); err == nil {
+		t.Fatal("expected error for tampered token, got nil")
+	}
+}
+
+func TestVerifyToken_Invalid(t *testing.T) {
+	p := newTestProvider(t)
+	_, err := p.VerifyToken("not.a.jwt")
+	if err == nil {
+		t.Fatal("expected error for invalid token, got nil")
+	}
+}
+
+func TestVerifyToken_WrongKey(t *testing.T) {
+	// Two independent providers each have their own keypair.
+	p1 := newTestProvider(t)
+	p2 := newTestProvider(t)
+
+	token, _, err := p1.GenerateKey("key", RoleRead, []string{"*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// p2 should reject a token signed by p1.
+	if _, err := p2.VerifyToken(token); err == nil {
+		t.Fatal("expected error: token signed by a different key should be rejected")
+	}
+}
+
+// --- RevokeKey ---
+
+func TestRevokeKey_RevokedTokenRejected(t *testing.T) {
+	p := newTestProvider(t)
+	token, policy, err := p.GenerateKey("revoke me", RoleWrite, []string{"*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Token is valid before revocation.
+	if _, err := p.VerifyToken(token); err != nil {
+		t.Fatalf("expected valid token before revoke, got: %v", err)
+	}
+
+	// Revoke by jti.
+	if err := p.RevokeKey(policy.ID); err != nil {
+		t.Fatalf("RevokeKey: %v", err)
+	}
+
+	// Token must be rejected after revocation.
+	if _, err := p.VerifyToken(token); err == nil {
+		t.Fatal("expected error for revoked token, got nil")
+	}
+}
+
+func TestRevokeKey_EmptyJTI(t *testing.T) {
+	p := newTestProvider(t)
+	if err := p.RevokeKey(""); err == nil {
+		t.Fatal("expected error for empty jti, got nil")
+	}
+}
+
+func TestRevokeKey_OtherTokensUnaffected(t *testing.T) {
+	p := newTestProvider(t)
+	token1, policy1, _ := p.GenerateKey("key1", RoleRead, []string{"*"})
+	token2, _, _ := p.GenerateKey("key2", RoleRead, []string{"*"})
+
+	_ = p.RevokeKey(policy1.ID)
+
+	if _, err := p.VerifyToken(token2); err != nil {
+		t.Fatalf("token2 should still be valid after revoking token1: %v", err)
+	}
+	_ = token1 // only token1 is revoked
+}
+
+// --- PublicKeyJWKS ---
+
+func TestPublicKeyJWKS_ValidJWK(t *testing.T) {
+	p := newTestProvider(t)
+	raw, err := p.PublicKeyJWKS()
+	if err != nil {
+		t.Fatalf("PublicKeyJWKS: %v", err)
+	}
+
+	var jwks struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.Unmarshal(raw, &jwks); err != nil {
+		t.Fatalf("invalid JWKS JSON: %v", err)
+	}
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(jwks.Keys))
+	}
+	key := jwks.Keys[0]
+	for _, field := range []string{"kty", "crv", "use", "alg", "x", "y"} {
+		if key[field] == "" {
+			t.Errorf("JWKS key missing field %q", field)
+		}
+	}
+	if key["kty"] != "EC" || key["crv"] != "P-256" || key["alg"] != "ES256" {
+		t.Errorf("unexpected JWKS key parameters: %v", key)
+	}
+}
+
+// --- KeyPair persistence ---
+
+func TestSignerPersistence_SameKeyAcrossProviders(t *testing.T) {
+	// Two JWTProviders sharing the same KV store should use the same keypair.
+	kv := core.NewKVStore()
+
+	p1, err := NewJWTProvider(kv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := p1.GenerateKey("key", RoleRead, []string{"*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// p2 loads the persisted key from the same KV store.
+	p2, err := NewJWTProvider(kv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// p2 must successfully verify a token issued by p1.
+	if _, err := p2.VerifyToken(token); err != nil {
+		t.Fatalf("p2 should verify token issued by p1 (same KV): %v", err)
+	}
+}
+
+// --- HasAccess (unchanged; tested here for completeness) ---
+
+func TestHasAccess_Admin(t *testing.T) {
+	p := &APIKeyPolicy{Role: RoleAdmin, Namespaces: []string{}}
+	if !p.HasAccess(RoleWrite, "any-namespace") {
+		t.Error("admin should have access to everything")
+	}
+}
+
+func TestHasAccess_WriteCanRead(t *testing.T) {
+	p := &APIKeyPolicy{Role: RoleWrite, Namespaces: []string{"ns1"}}
+	if !p.HasAccess(RoleRead, "ns1") {
+		t.Error("write role should satisfy read requirement")
+	}
+}
+
+func TestHasAccess_ReadCannotWrite(t *testing.T) {
+	p := &APIKeyPolicy{Role: RoleRead, Namespaces: []string{"ns1"}}
+	if p.HasAccess(RoleWrite, "ns1") {
+		t.Error("read role should not satisfy write requirement")
+	}
+}
+
+func TestHasAccess_WrongNamespace(t *testing.T) {
+	p := &APIKeyPolicy{Role: RoleWrite, Namespaces: []string{"ns1"}}
+	if p.HasAccess(RoleRead, "ns2") {
+		t.Error("should not have access to a namespace not in the policy")
+	}
+}
+
+func TestHasAccess_Wildcard(t *testing.T) {
+	p := &APIKeyPolicy{Role: RoleWrite, Namespaces: []string{"*"}}
+	if !p.HasAccess(RoleWrite, "any-namespace") {
+		t.Error("wildcard namespace should grant access to all namespaces")
+	}
+}
+
+// --- Token TTL sanity ---
+
+func TestGenerateKey_ExpClaimIsInFuture(t *testing.T) {
+	p := newTestProvider(t)
+	token, _, err := p.GenerateKey("key", RoleRead, []string{"*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// VerifyToken succeeds only if exp > now (library enforces this automatically).
+	got, err := p.VerifyToken(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// CreatedAt should be within the last few seconds.
+	if time.Now().Unix()-got.CreatedAt > 5 {
+		t.Errorf("CreatedAt is too far in the past: %d", got.CreatedAt)
+	}
+}

--- a/pkg/auth/jwt_provider_test.go
+++ b/pkg/auth/jwt_provider_test.go
@@ -96,8 +96,17 @@ func TestVerifyToken_Tampered(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Flip the last character of the signature to invalidate it.
-	tampered := token[:len(token)-1] + "X"
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT segments, got %d", len(parts))
+	}
+
+	// Corrupt the signature segment: replace every character with 'A'.
+	// This guarantees the ECDSA signature no longer matches the header+payload,
+	// regardless of base64url padding edge cases.
+	parts[2] = strings.Repeat("A", len(parts[2]))
+	tampered := strings.Join(parts, ".")
+
 	if _, err := p.VerifyToken(tampered); err == nil {
 		t.Fatal("expected error for tampered token, got nil")
 	}

--- a/pkg/auth/keys.go
+++ b/pkg/auth/keys.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+	"log"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/sanonone/kektordb/pkg/core"
+)
+
+// Signer encapsulates the ECDSA private key and exposes only the operations
+// the rest of the package needs. The raw key is never returned to callers.
+type Signer struct {
+	priv *ecdsa.PrivateKey
+}
+
+// SignToken signs a JWT claims set and returns the compact signed token string.
+// This is the only path through which a token can be minted.
+func (s *Signer) SignToken(claims jwt.Claims) (string, error) {
+	return jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(s.priv)
+}
+
+// PublicKey returns the public half of the keypair for token verification
+// and JWKS endpoint serving. Read-only; cannot be used to sign.
+func (s *Signer) PublicKey() *ecdsa.PublicKey {
+	return &s.priv.PublicKey
+}
+
+// loadOrCreateSigner loads the persisted ECDSA P-256 private key from the KV store,
+// or generates and persists a new one if none exists. Returns a Signer, so the
+// private key is never accessible outside this package.
+func loadOrCreateSigner(kv *core.KVStore) (*Signer, error) {
+	const kvKey = "_sys_auth::ecdsa_private_key"
+
+	if raw, ok := kv.Get(kvKey); ok {
+		parsed, err := x509.ParsePKCS8PrivateKey(raw)
+		if err != nil {
+			return nil, fmt.Errorf("auth: failed to parse stored private key: %w", err)
+		}
+		ecKey, ok := parsed.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("auth: stored key is not an ECDSA private key")
+		}
+		return &Signer{priv: ecKey}, nil
+	}
+
+	log.Println("auth: no signing key found — generating new ECDSA P-256 keypair")
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("auth: failed to generate ECDSA key: %w", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("auth: failed to marshal private key: %w", err)
+	}
+	kv.Set(kvKey, der)
+	return &Signer{priv: priv}, nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1191,7 +1191,8 @@ type apiKeyRequest struct {
 }
 
 type apiKeyResponse struct {
-	Token string `json:"token"`
+	Token  string                 `json:"token"`
+	Policy map[string]interface{} `json:"policy"`
 }
 
 type exportResponse struct {
@@ -1479,33 +1480,52 @@ func (c *Client) Save() error {
 // --- Auth ---
 
 // CreateApiKey creates a new API key with RBAC permissions.
+// Returns the compact JWT token string and the policy (which contains the jti in "id").
 func (c *Client) CreateApiKey(role, namespace string) (string, error) {
+	_, token, err := c.CreateApiKeyWithPolicy(role, namespace)
+	return token, err
+}
+
+// CreateApiKeyWithPolicy creates a new API key and returns both the jti and the token.
+func (c *Client) CreateApiKeyWithPolicy(role, namespace string) (jti string, token string, err error) {
 	req := apiKeyRequest{
 		Role:      role,
 		Namespace: namespace,
 	}
 	respBody, err := c.jsonRequest(http.MethodPost, "/auth/keys", req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	var resp apiKeyResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return "", fmt.Errorf("invalid JSON: %w", err)
+		return "", "", fmt.Errorf("invalid JSON: %w", err)
 	}
-	return resp.Token, nil
+	if id, ok := resp.Policy["id"].(string); ok {
+		jti = id
+	}
+	return jti, resp.Token, nil
 }
 
-// ListApiKeys lists all API key policies.
+// ListApiKeys returns the list of revoked token IDs (jti denylist).
+// Active JWT tokens are self-contained and not stored server-side, so only
+// revoked token IDs are tracked.
 func (c *Client) ListApiKeys() ([]map[string]interface{}, error) {
 	respBody, err := c.jsonRequest(http.MethodGet, "/auth/keys", nil)
 	if err != nil {
 		return nil, err
 	}
-	var resp []map[string]interface{}
+	var resp struct {
+		RevokedTokenIDs []string `json:"revoked_token_ids"`
+	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
-	return resp, nil
+	// Convert to the existing return type for backward compatibility with callers.
+	result := make([]map[string]interface{}, 0, len(resp.RevokedTokenIDs))
+	for _, jti := range resp.RevokedTokenIDs {
+		result = append(result, map[string]interface{}{"id": jti})
+	}
+	return result, nil
 }
 
 // RevokeApiKey revokes an API key.

--- a/pkg/client/e2e_test.go
+++ b/pkg/client/e2e_test.go
@@ -1194,8 +1194,6 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("ListApiKeys", func(t *testing.T) {
-		c.CreateApiKey("read", "")
-
 		keys, err := c.ListApiKeys()
 		if err != nil {
 			t.Fatalf("ListApiKeys failed: %v", err)
@@ -1206,25 +1204,16 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("RevokeApiKey", func(t *testing.T) {
-		keys, err := c.ListApiKeys()
+		// Get the jti from CreateApiKeyWithPolicy so we have something to revoke.
+		jti, _, err := c.CreateApiKeyWithPolicy("read", "")
 		if err != nil {
-			t.Fatalf("ListApiKeys failed: %v", err)
+			t.Fatalf("CreateApiKeyWithPolicy failed: %v", err)
 		}
-
-		if len(keys) > 0 {
-			keyID := ""
-			if id, ok := keys[0]["id"].(string); ok {
-				keyID = id
-			} else if key, ok := keys[0]["key"].(string); ok {
-				keyID = key
-			}
-
-			if keyID != "" {
-				err = c.RevokeApiKey(keyID)
-				if err != nil {
-					t.Fatalf("RevokeApiKey failed: %v", err)
-				}
-			}
+		if jti == "" {
+			t.Fatal("Expected jti to be returned in policy")
+		}
+		if err := c.RevokeApiKey(jti); err != nil {
+			t.Fatalf("RevokeApiKey failed: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Description

Replace the old opaque API key system (kek_<hex>) with signed JWTs and a pluggable auth backend interface. Previously, every authenticated request required a KV store lookup to reconstruct the token's policy, tokens had no expiry, and there was no standard mechanism for external services to verify tokens independently.

New design:

Issues ES256-signed JWTs with exp/nbf/iat/jti and embedded KektorClaims (role, namespaces). Policy is self-contained in the token — no KV lookup on verify for valid tokens.
Introduces TokenVerifier and KeyManager interfaces so a future OIDC provider can slot in without changing the middleware or HTTP handlers.
Exposes GET /.well-known/jwks.json (unauthenticated) so API gateways and external services can verify tokens locally.
Wraps the ECDSA private key in a Signer capability object — the raw key is never accessible outside auth.
Revocation is handled via a jti denylist in KV (write-on-revoke, single lookup on verify).

## Related Issue

<!-- Closes #123 or related to #456 -->

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [ ] `perf` — Performance improvement
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `chore` — Maintenance, dependencies, CI
- [ ] `test` — Adding or updating tests

## Breaking Changes

- [x] Yes — **BREAKING** (describe below)
- [ ] No

<!-- If yes, explain the change and migration path. -->
Existing kek_<hex> tokens issued by the old AuthService are not accepted by JWTProvider.VerifyToken since they are not JWTs.

Migration path:
On upgrade the server generates a new ECDSA P-256 keypair on first startup and persists it in the KV store.
All existing API keys must be re-issued via POST /auth/keys.
The master root token (KEKTORDB_AUTH_TOKEN env var) is unaffected — the middleware bypass is unchanged and continues to work as the bootstrap credential.
DELETE /auth/keys/{id} — the id is now the jti (UUID from policy.id in the create response), not the SHA-256 hash of the old opaque token

## Testing Done

# Unit tests — JWTProvider methods, key persistence, HasAccess, TTL
go test -count=1 ./pkg/auth/...

# Integration tests — RBAC enforcement, namespace isolation, revocation, JWKS endpoint
go test -count=1 ./internal/server/...

# Full build
go build ./...

# Tidy
go mod tidy

## Checklist

- [x] Code is formatted (`gofmt -l .` shows no changes)
- [x] `go vet ./...` passes
- [ ] `go test -race -short ./...` passes in Pure Go mode
- [ ] `make test-rust` passes (if changes affect `native/compute/`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (if API or behavior change)
- [ ] `make clean` run before final commit — no generated files included
- [ ] `go mod tidy` reports clean `go.mod` / `go.sum`
