### PR TITLE
Added Support for Gemini api and embedded to the configs

### DIFF
--- a/cmd/kektordb/main.go
+++ b/cmd/kektordb/main.go
@@ -261,10 +261,18 @@ func main() {
 			)
 
 			switch proxyCfg.EmbedderType {
-			case "openai", "openai_compatible":
-				proxyCfg.Embedder = embeddings.NewOllamaEmbedder(
+			case "gemini", "google":
+				proxyCfg.Embedder = embeddings.NewGeminiEmbedder(
 					proxyCfg.EmbedderURL,
 					proxyCfg.EmbedderModel,
+					proxyCfg.EmbedderAPIKey,
+					proxyCfg.EmbedderTimeout,
+				)
+			case "openai", "openai_compatible":
+				proxyCfg.Embedder = embeddings.NewOpenAIEmbedder(
+					proxyCfg.EmbedderURL,
+					proxyCfg.EmbedderModel,
+					proxyCfg.EmbedderAPIKey,
 					proxyCfg.EmbedderTimeout,
 				)
 			default:

--- a/cognitive.yaml
+++ b/cognitive.yaml
@@ -70,13 +70,17 @@ llm:
   # API endpoint (OpenAI-compatible)
   # Ollama: "http://localhost:11434/v1"
   # OpenAI: "https://api.openai.com/v1"
-  base_url: "http://localhost:11434/v1"
+  provider: "gemini"
+  # base_url: "http://localhost:11434/v1"
+  base_url: "https://generativelanguage.googleapis.com/v1beta/interactions"
 
   # Model name
-  model: "gemma4:latest"
+  # model: "gemma4:latest"
+  model: "gemini-3.5-flash"
 
   # API key (required for OpenAI, ignored by Ollama)
-  api_key: "kektor"
+  # api_key: "kektor"
+  api_key: "{GEMINI_API_KEY}"
 
   # Temperature (0.0 = deterministic, 1.0 = creative)
   temperature: 0.5

--- a/internal/server/cognitive_config.go
+++ b/internal/server/cognitive_config.go
@@ -86,6 +86,7 @@ type AutoActionResolveYAML struct {
 
 // LLMConfigYAML holds the LLM settings for the cognitive engine.
 type LLMConfigYAML struct {
+	Provider    string  `yaml:"provider"`
 	BaseURL     string  `yaml:"base_url"`
 	Model       string  `yaml:"model"`
 	APIKey      string  `yaml:"api_key"`
@@ -229,6 +230,12 @@ func LoadCognitiveConfig(path string) (cognitive.Config, llm.Config, error) {
 
 	// Build LLM config
 	llmCfg := llm.DefaultConfig()
+	if cfg.LLM.Provider != "" {
+		llmCfg.Provider = cfg.LLM.Provider
+		llmCfg.BaseURL = ""
+		llmCfg.Model = ""
+		llmCfg.APIKey = ""
+	}
 	if cfg.LLM.BaseURL != "" {
 		llmCfg.BaseURL = cfg.LLM.BaseURL
 	}

--- a/internal/server/vectorizer_service.go
+++ b/internal/server/vectorizer_service.go
@@ -121,6 +121,15 @@ func NewVectorizerService(server *Server, assetsDir string) (*VectorizerService,
 		var embedder embeddings.Embedder
 
 		switch cfg.Embedder.Type {
+		case "gemini", "google":
+			embedder = embeddings.NewGeminiEmbedder(
+				ragConfig.EmbedderURL,
+				ragConfig.EmbedderModel,
+				cfg.Embedder.APIKey,
+				ragConfig.EmbedderTimeout,
+			)
+			log.Printf("   -> Using Gemini embedder for '%s'", cfg.Name)
+
 		case "openai", "openai_compatible":
 			embedder = embeddings.NewOpenAIEmbedder(
 				ragConfig.EmbedderURL,
@@ -144,7 +153,7 @@ func NewVectorizerService(server *Server, assetsDir string) (*VectorizerService,
 		var llmClient llm.Client
 		if ragConfig.GraphEntityExtraction {
 			// Se l'utente non ha configurato l'URL nel blocco LLM, usiamo un default sensato o fallback
-			if ragConfig.LLMConfig.BaseURL == "" {
+			if ragConfig.LLMConfig.BaseURL == "" && ragConfig.LLMConfig.Provider == "" {
 				// Fallback ai default di pkg/llm se la sezione manca
 				ragConfig.LLMConfig = llm.DefaultConfig()
 			}
@@ -155,7 +164,7 @@ func NewVectorizerService(server *Server, assetsDir string) (*VectorizerService,
 
 		var visionClient llm.Client
 		// Se l'URL è settato, vuol dire che l'utente vuole la visione
-		if ragConfig.VisionLLMConfig.BaseURL != "" {
+		if ragConfig.VisionLLMConfig.BaseURL != "" || ragConfig.VisionLLMConfig.Provider != "" {
 			log.Printf("[Vectorizer] Enabling Vision Pipeline using (%s)", ragConfig.VisionLLMConfig.Model)
 			visionClient = llm.NewClient(ragConfig.VisionLLMConfig)
 		}

--- a/pkg/embeddings/gemini.go
+++ b/pkg/embeddings/gemini.go
@@ -1,0 +1,143 @@
+package embeddings
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// GeminiEmbedder implements Embedder using Google's native embedContent API.
+type GeminiEmbedder struct {
+	URL    string
+	Model  string
+	APIKey string
+	Client *http.Client
+}
+
+var _ Embedder = (*GeminiEmbedder)(nil)
+
+func NewGeminiEmbedder(urlStr, model, apiKey string, timeout time.Duration) *GeminiEmbedder {
+	if model == "" {
+		model = "gemini-embedding-001"
+	}
+	if urlStr == "" {
+		urlStr = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/%s:embedContent", geminiModelResource(model))
+	}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+
+	return &GeminiEmbedder{
+		URL:    strings.TrimRight(urlStr, "/"),
+		Model:  model,
+		APIKey: apiKey,
+		Client: &http.Client{Timeout: timeout},
+	}
+}
+
+func (e *GeminiEmbedder) Embed(text string) ([]float32, error) {
+	payload := map[string]interface{}{
+		"model": geminiModelResource(e.Model),
+		"content": map[string]interface{}{
+			"parts": []map[string]string{
+				{"text": text},
+			},
+		},
+	}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := e.endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gemini embedder request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey := e.apiKey(); apiKey != "" {
+		req.Header.Set("x-goog-api-key", apiKey)
+	}
+
+	resp, err := e.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gemini embedder request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gemini embedder returned status: %s: %s", resp.Status, string(bodyBytes))
+	}
+
+	var geminiResp struct {
+		Embedding struct {
+			Values []float32 `json:"values"`
+		} `json:"embedding"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(bodyBytes, &geminiResp); err != nil {
+		return nil, fmt.Errorf("failed to decode gemini embedder response: %w", err)
+	}
+	if geminiResp.Error != nil {
+		return nil, fmt.Errorf("gemini embedder provider error: %s", geminiResp.Error.Message)
+	}
+	if len(geminiResp.Embedding.Values) == 0 {
+		return nil, fmt.Errorf("gemini embedder returned no values")
+	}
+
+	return geminiResp.Embedding.Values, nil
+}
+
+func (e *GeminiEmbedder) endpoint() (string, error) {
+	endpoint := e.URL
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/%s:embedContent", geminiModelResource(e.Model))
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid gemini embedder endpoint: %w", err)
+	}
+	if apiKey := e.apiKey(); apiKey != "" && u.Query().Get("key") == "" {
+		q := u.Query()
+		q.Set("key", apiKey)
+		u.RawQuery = q.Encode()
+	}
+
+	return u.String(), nil
+}
+
+func (e *GeminiEmbedder) apiKey() string {
+	if e.APIKey != "" {
+		return e.APIKey
+	}
+	if key := os.Getenv("GEMINI_API_KEY"); key != "" {
+		return key
+	}
+	return os.Getenv("GOOGLE_API_KEY")
+}
+
+func geminiModelResource(model string) string {
+	model = strings.TrimSpace(strings.TrimPrefix(model, "/"))
+	if model == "" {
+		model = "gemini-embedding-001"
+	}
+	if strings.HasPrefix(model, "models/") {
+		return model
+	}
+	return "models/" + model
+}

--- a/pkg/embeddings/gemini_test.go
+++ b/pkg/embeddings/gemini_test.go
@@ -1,0 +1,67 @@
+package embeddings
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGeminiEmbedder_RequestAndResponse(t *testing.T) {
+	var gotReq struct {
+		Model   string `json:"model"`
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/models/gemini-embedding-2:embedContent" {
+			t.Errorf("path = %s, want Gemini embedContent path", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") != "secret" {
+			t.Errorf("key query = %q, want secret", r.URL.Query().Get("key"))
+		}
+		if r.Header.Get("x-goog-api-key") != "secret" {
+			t.Errorf("x-goog-api-key header = %q, want secret", r.Header.Get("x-goog-api-key"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"embedding": {
+				"values": [0.1, 0.2, 0.3]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(
+		server.URL+"/models/gemini-embedding-2:embedContent",
+		"gemini-embedding-2",
+		"secret",
+		time.Second,
+	)
+
+	got, err := embedder.Embed("hello")
+	if err != nil {
+		t.Fatalf("Embed returned error: %v", err)
+	}
+	if len(got) != 3 || got[0] != 0.1 || got[1] != 0.2 || got[2] != 0.3 {
+		t.Fatalf("embedding = %#v, want [0.1 0.2 0.3]", got)
+	}
+	if gotReq.Model != "models/gemini-embedding-2" {
+		t.Errorf("model = %q, want models/gemini-embedding-2", gotReq.Model)
+	}
+	if len(gotReq.Content.Parts) != 1 || gotReq.Content.Parts[0].Text != "hello" {
+		t.Fatalf("parts = %#v, want one text part", gotReq.Content.Parts)
+	}
+}

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -32,11 +32,26 @@ type OpenAIClient struct {
 }
 
 // NewClient initializes a new LLM client based on the configured provider.
-// All supported providers (OpenAI, Ollama, HuggingFace) use the OpenAI-compatible
-// /chat/completions endpoint, so they share the same underlying transport.
+// OpenAI-compatible providers share /chat/completions. Gemini uses its native
+// generateContent API behind the same Client interface.
 func NewClient(cfg Config) Client {
+	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
+	if provider == "" && strings.Contains(cfg.BaseURL, "generativelanguage.googleapis.com") {
+		provider = "gemini"
+	}
+	cfg.Provider = provider
+
 	// Set provider-specific defaults
-	switch cfg.Provider {
+	switch provider {
+	case "gemini", "google":
+		if cfg.BaseURL == "" {
+			cfg.BaseURL = "https://generativelanguage.googleapis.com/v1beta"
+		}
+		cfg.BaseURL = strings.TrimSuffix(cfg.BaseURL, "/")
+		if cfg.Model == "" {
+			cfg.Model = "gemini-2.0-flash"
+		}
+		return NewGeminiClient(cfg)
 	case "huggingface":
 		if cfg.BaseURL == "" {
 			cfg.BaseURL = "https://api-inference.huggingface.co/v1"

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -1,6 +1,9 @@
 package llm
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -65,5 +68,173 @@ func TestNewClient_ReturnsInterface(t *testing.T) {
 	c = NewClient(Config{Provider: "huggingface"})
 	if c == nil {
 		t.Fatal("expected non-nil Client")
+	}
+}
+
+func TestNewClient_Gemini(t *testing.T) {
+	client := NewClient(Config{Provider: "gemini"})
+	gc, ok := client.(*GeminiClient)
+	if !ok {
+		t.Fatal("NewClient did not return *GeminiClient")
+	}
+	if gc.cfg.BaseURL != "https://generativelanguage.googleapis.com/v1beta" {
+		t.Errorf("BaseURL = %q, want Gemini default", gc.cfg.BaseURL)
+	}
+	if gc.cfg.Model != "gemini-2.0-flash" {
+		t.Errorf("Model = %q, want Gemini default", gc.cfg.Model)
+	}
+}
+
+func TestNewClient_GeminiDetectedFromBaseURL(t *testing.T) {
+	client := NewClient(Config{
+		BaseURL: "https://generativelanguage.googleapis.com/v1beta/interactions",
+		Model:   "gemini-3.5-flash",
+	})
+	if _, ok := client.(*GeminiClient); !ok {
+		t.Fatal("NewClient did not detect Gemini from generativelanguage base_url")
+	}
+}
+
+func TestGeminiClientChat_RequestAndResponse(t *testing.T) {
+	var gotReq geminiGenerateContentRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/models/gemini-test:generateContent" {
+			t.Errorf("path = %s, want Gemini generateContent path", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") != "secret" {
+			t.Errorf("key query = %q, want secret", r.URL.Query().Get("key"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"candidates": [{
+				"content": {
+					"parts": [
+						{"text": "hello "},
+						{"text": "world"}
+					]
+				}
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Provider:    "gemini",
+		BaseURL:     server.URL,
+		APIKey:      "secret",
+		Model:       "gemini-test",
+		Temperature: 0.2,
+		MaxTokens:   64,
+	})
+
+	got, err := client.Chat("system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("Chat = %q, want %q", got, "hello world")
+	}
+
+	if gotReq.SystemInstruction == nil || len(gotReq.SystemInstruction.Parts) != 1 {
+		t.Fatal("expected systemInstruction with one text part")
+	}
+	if gotReq.SystemInstruction.Parts[0].Text != "system prompt" {
+		t.Errorf("systemInstruction text = %q", gotReq.SystemInstruction.Parts[0].Text)
+	}
+	if len(gotReq.Contents) != 1 || gotReq.Contents[0].Role != "user" {
+		t.Fatalf("contents = %#v, want one user content", gotReq.Contents)
+	}
+	if len(gotReq.Contents[0].Parts) != 1 || gotReq.Contents[0].Parts[0].Text != "user prompt" {
+		t.Fatalf("user parts = %#v, want user prompt text", gotReq.Contents[0].Parts)
+	}
+	if gotReq.GenerationConfig == nil {
+		t.Fatal("expected generationConfig")
+	}
+	if gotReq.GenerationConfig.Temperature != 0.2 {
+		t.Errorf("temperature = %v, want 0.2", gotReq.GenerationConfig.Temperature)
+	}
+	if gotReq.GenerationConfig.MaxOutputTokens != 64 {
+		t.Errorf("maxOutputTokens = %d, want 64", gotReq.GenerationConfig.MaxOutputTokens)
+	}
+}
+
+func TestGeminiClientChat_InteractionsRequestAndResponse(t *testing.T) {
+	var gotReq geminiInteractionRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1beta/interactions" {
+			t.Errorf("path = %s, want /v1beta/interactions", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") != "secret" {
+			t.Errorf("key query = %q, want secret", r.URL.Query().Get("key"))
+		}
+		if r.Header.Get("x-goog-api-key") != "secret" {
+			t.Errorf("x-goog-api-key header = %q, want secret", r.Header.Get("x-goog-api-key"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status": "completed",
+			"steps": [{
+				"type": "model_output",
+				"content": [
+					{"type": "text", "text": "interaction "},
+					{"type": "text", "text": "response"}
+				]
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Provider:    "gemini",
+		BaseURL:     server.URL + "/v1beta/interactions",
+		APIKey:      "secret",
+		Model:       "gemini-3.5-flash",
+		Temperature: 0.3,
+		MaxTokens:   128,
+	})
+
+	got, err := client.Chat("system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if got != "interaction response" {
+		t.Errorf("Chat = %q, want %q", got, "interaction response")
+	}
+	if gotReq.Model != "gemini-3.5-flash" {
+		t.Errorf("model = %q, want gemini-3.5-flash", gotReq.Model)
+	}
+	if gotReq.Input != "user prompt" {
+		t.Errorf("input = %#v, want user prompt", gotReq.Input)
+	}
+	if gotReq.SystemInstruction != "system prompt" {
+		t.Errorf("system_instruction = %q, want system prompt", gotReq.SystemInstruction)
+	}
+	if gotReq.Stream {
+		t.Error("stream = true, want false")
+	}
+	if gotReq.GenerationConfig == nil {
+		t.Fatal("expected generation_config")
+	}
+	if gotReq.GenerationConfig.Temperature != 0.3 {
+		t.Errorf("temperature = %v, want 0.3", gotReq.GenerationConfig.Temperature)
+	}
+	if gotReq.GenerationConfig.MaxOutputTokens != 128 {
+		t.Errorf("max_output_tokens = %d, want 128", gotReq.GenerationConfig.MaxOutputTokens)
 	}
 }

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	// - "openai" (default): OpenAI, LocalAI, vLLM
 	// - "ollama": Ollama local models
 	// - "huggingface": HuggingFace Serverless Inference API
+	// - "gemini": Google Gemini API
 	Provider string `yaml:"provider" json:"provider"`
 
 	// BaseURL is the API endpoint.

--- a/pkg/llm/gemini_client.go
+++ b/pkg/llm/gemini_client.go
@@ -1,0 +1,408 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// GeminiClient implements Client using Google's native generateContent API.
+type GeminiClient struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+var _ Client = (*GeminiClient)(nil)
+
+type geminiGenerateContentRequest struct {
+	Contents          []geminiContent         `json:"contents"`
+	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	Temperature     float64 `json:"temperature"`
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text       string            `json:"text,omitempty"`
+	InlineData *geminiInlineData `json:"inline_data,omitempty"`
+}
+
+type geminiInlineData struct {
+	MimeType string `json:"mime_type"`
+	Data     string `json:"data"`
+}
+
+type geminiGenerateContentResponse struct {
+	Candidates []struct {
+		Content      geminiContent `json:"content"`
+		FinishReason string        `json:"finishReason"`
+	} `json:"candidates"`
+	PromptFeedback *struct {
+		BlockReason string `json:"blockReason"`
+	} `json:"promptFeedback,omitempty"`
+	Error *APIError `json:"error,omitempty"`
+}
+
+type geminiInteractionRequest struct {
+	Model             string                             `json:"model,omitempty"`
+	Input             interface{}                        `json:"input"`
+	SystemInstruction string                             `json:"system_instruction,omitempty"`
+	Stream            bool                               `json:"stream"`
+	GenerationConfig  *geminiInteractionGenerationConfig `json:"generation_config,omitempty"`
+}
+
+type geminiInteractionGenerationConfig struct {
+	Temperature     float64 `json:"temperature"`
+	MaxOutputTokens int     `json:"max_output_tokens,omitempty"`
+}
+
+type geminiInteractionContent struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+}
+
+type geminiInteractionResponse struct {
+	Status string `json:"status"`
+	Steps  []struct {
+		Type    string                     `json:"type"`
+		Content []geminiInteractionContent `json:"content"`
+	} `json:"steps"`
+	Error *APIError `json:"error,omitempty"`
+}
+
+// NewGeminiClient creates a Gemini API client.
+func NewGeminiClient(cfg Config) *GeminiClient {
+	return &GeminiClient{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}
+}
+
+// Chat performs a text-only generateContent request.
+func (c *GeminiClient) Chat(systemPrompt, userQuery string) (string, error) {
+	if c.usesInteractionsAPI() {
+		reqBody := c.newInteractionRequest(systemPrompt, userQuery)
+		return c.sendInteractionRequest(reqBody)
+	}
+
+	reqBody := c.newRequest(systemPrompt, textParts(userQuery))
+	return c.sendGenerateContentRequest(reqBody)
+}
+
+// ChatWithImages sends text and inline image data to a multimodal Gemini model.
+func (c *GeminiClient) ChatWithImages(systemPrompt, userQuery string, images [][]byte) (string, error) {
+	if c.usesInteractionsAPI() {
+		reqBody := c.newInteractionRequest(systemPrompt, c.interactionParts(userQuery, images))
+		return c.sendInteractionRequest(reqBody)
+	}
+
+	parts := textParts(userQuery)
+	for _, imgBytes := range images {
+		if len(imgBytes) == 0 {
+			continue
+		}
+
+		parts = append(parts, geminiPart{
+			InlineData: &geminiInlineData{
+				MimeType: http.DetectContentType(imgBytes),
+				Data:     base64.StdEncoding.EncodeToString(imgBytes),
+			},
+		})
+	}
+
+	reqBody := c.newRequest(systemPrompt, parts)
+	return c.sendGenerateContentRequest(reqBody)
+}
+
+func (c *GeminiClient) newInteractionRequest(systemPrompt string, input interface{}) geminiInteractionRequest {
+	if input == nil || input == "" {
+		input = " "
+	}
+
+	reqBody := geminiInteractionRequest{
+		Model:  c.cfg.Model,
+		Input:  input,
+		Stream: false,
+		GenerationConfig: &geminiInteractionGenerationConfig{
+			Temperature: c.cfg.Temperature,
+		},
+	}
+	if systemPrompt != "" {
+		reqBody.SystemInstruction = systemPrompt
+	}
+	if c.cfg.MaxTokens > 0 {
+		reqBody.GenerationConfig.MaxOutputTokens = c.cfg.MaxTokens
+	}
+
+	return reqBody
+}
+
+func (c *GeminiClient) interactionParts(userQuery string, images [][]byte) []geminiInteractionContent {
+	parts := []geminiInteractionContent{}
+	if userQuery != "" {
+		parts = append(parts, geminiInteractionContent{
+			Type: "text",
+			Text: userQuery,
+		})
+	}
+
+	for _, imgBytes := range images {
+		if len(imgBytes) == 0 {
+			continue
+		}
+
+		parts = append(parts, geminiInteractionContent{
+			Type:     "image",
+			MimeType: http.DetectContentType(imgBytes),
+			Data:     base64.StdEncoding.EncodeToString(imgBytes),
+		})
+	}
+
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
+}
+
+func (c *GeminiClient) newRequest(systemPrompt string, userParts []geminiPart) geminiGenerateContentRequest {
+	if len(userParts) == 0 && systemPrompt != "" {
+		userParts = textParts(systemPrompt)
+		systemPrompt = ""
+	}
+	if len(userParts) == 0 {
+		userParts = textParts(" ")
+	}
+
+	reqBody := geminiGenerateContentRequest{
+		Contents: []geminiContent{
+			{
+				Role:  "user",
+				Parts: userParts,
+			},
+		},
+		GenerationConfig: &geminiGenerationConfig{
+			Temperature: c.cfg.Temperature,
+		},
+	}
+
+	if systemPrompt != "" {
+		reqBody.SystemInstruction = &geminiContent{
+			Parts: textParts(systemPrompt),
+		}
+	}
+	if c.cfg.MaxTokens > 0 {
+		reqBody.GenerationConfig.MaxOutputTokens = c.cfg.MaxTokens
+	}
+
+	return reqBody
+}
+
+func textParts(text string) []geminiPart {
+	if text == "" {
+		return nil
+	}
+	return []geminiPart{{Text: text}}
+}
+
+func (c *GeminiClient) sendGenerateContentRequest(payload geminiGenerateContentRequest) (string, error) {
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal gemini request: %w", err)
+	}
+
+	endpoint, err := c.endpoint()
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create gemini request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey := c.apiKey(); apiKey != "" {
+		req.Header.Set("x-goog-api-key", apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini api error (status %d): %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var geminiResp geminiGenerateContentResponse
+	if err := json.Unmarshal(bodyBytes, &geminiResp); err != nil {
+		return "", fmt.Errorf("failed to decode gemini response: %w", err)
+	}
+	if geminiResp.Error != nil {
+		return "", fmt.Errorf("provider error: %s", geminiResp.Error.Message)
+	}
+	if len(geminiResp.Candidates) == 0 {
+		if geminiResp.PromptFeedback != nil && geminiResp.PromptFeedback.BlockReason != "" {
+			return "", fmt.Errorf("gemini blocked prompt: %s", geminiResp.PromptFeedback.BlockReason)
+		}
+		return "", fmt.Errorf("empty response from gemini")
+	}
+
+	var out strings.Builder
+	for _, part := range geminiResp.Candidates[0].Content.Parts {
+		out.WriteString(part.Text)
+	}
+	if out.Len() == 0 {
+		if geminiResp.Candidates[0].FinishReason != "" {
+			return "", fmt.Errorf("gemini returned no text (finish reason: %s)", geminiResp.Candidates[0].FinishReason)
+		}
+		return "", fmt.Errorf("gemini returned no text")
+	}
+
+	return out.String(), nil
+}
+
+func (c *GeminiClient) sendInteractionRequest(payload geminiInteractionRequest) (string, error) {
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal gemini interaction request: %w", err)
+	}
+
+	endpoint, err := c.interactionEndpoint()
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create gemini interaction request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey := c.apiKey(); apiKey != "" {
+		req.Header.Set("x-goog-api-key", apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini interaction connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini interaction api error (status %d): %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var interactionResp geminiInteractionResponse
+	if err := json.Unmarshal(bodyBytes, &interactionResp); err != nil {
+		return "", fmt.Errorf("failed to decode gemini interaction response: %w", err)
+	}
+	if interactionResp.Error != nil {
+		return "", fmt.Errorf("provider error: %s", interactionResp.Error.Message)
+	}
+
+	var out strings.Builder
+	for _, step := range interactionResp.Steps {
+		if step.Type != "model_output" {
+			continue
+		}
+		for _, content := range step.Content {
+			if content.Type == "text" {
+				out.WriteString(content.Text)
+			}
+		}
+	}
+	if out.Len() == 0 {
+		if interactionResp.Status != "" {
+			return "", fmt.Errorf("gemini interaction returned no text (status: %s)", interactionResp.Status)
+		}
+		return "", fmt.Errorf("gemini interaction returned no text")
+	}
+
+	return out.String(), nil
+}
+
+func (c *GeminiClient) usesInteractionsAPI() bool {
+	return strings.Contains(strings.TrimRight(c.cfg.BaseURL, "/"), "/interactions")
+}
+
+func (c *GeminiClient) apiKey() string {
+	if c.cfg.APIKey != "" {
+		return c.cfg.APIKey
+	}
+	if key := os.Getenv("GEMINI_API_KEY"); key != "" {
+		return key
+	}
+	return os.Getenv("GOOGLE_API_KEY")
+}
+
+func (c *GeminiClient) endpoint() (string, error) {
+	baseURL := strings.TrimRight(c.cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com/v1beta"
+	}
+
+	endpoint := baseURL
+	if !strings.Contains(endpoint, ":generateContent") {
+		model := strings.TrimSpace(c.cfg.Model)
+		if model == "" {
+			return "", fmt.Errorf("gemini model is required")
+		}
+		model = strings.TrimPrefix(model, "/")
+		if !strings.HasPrefix(model, "models/") && !strings.HasPrefix(model, "tunedModels/") {
+			model = "models/" + model
+		}
+		endpoint = fmt.Sprintf("%s/%s:generateContent", baseURL, model)
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid gemini endpoint: %w", err)
+	}
+	if apiKey := c.apiKey(); apiKey != "" && u.Query().Get("key") == "" {
+		q := u.Query()
+		q.Set("key", apiKey)
+		u.RawQuery = q.Encode()
+	}
+
+	return u.String(), nil
+}
+
+func (c *GeminiClient) interactionEndpoint() (string, error) {
+	endpoint := strings.TrimRight(c.cfg.BaseURL, "/")
+	if endpoint == "" {
+		endpoint = "https://generativelanguage.googleapis.com/v1beta/interactions"
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid gemini interaction endpoint: %w", err)
+	}
+	if apiKey := c.apiKey(); apiKey != "" && u.Query().Get("key") == "" {
+		q := u.Query()
+		q.Set("key", apiKey)
+		u.RawQuery = q.Encode()
+	}
+
+	return u.String(), nil
+}

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -20,9 +20,10 @@ type Config struct {
 	AssetBaseURL string `yaml:"asset_base_url"`
 
 	// Embedder Settings (Specific for Proxy)
-	EmbedderType    string              `yaml:"embedder_type"` // "ollama_api" (future: "openai")
+	EmbedderType    string              `yaml:"embedder_type"` // "ollama_api", "openai", "gemini"
 	EmbedderURL     string              `yaml:"embedder_url"`
 	EmbedderModel   string              `yaml:"embedder_model"`
+	EmbedderAPIKey  string              `yaml:"embedder_api_key"`
 	EmbedderTimeout time.Duration       `yaml:"embedder_timeout"`
 	Embedder        embeddings.Embedder `yaml:"-" json:"-"`
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -75,10 +75,10 @@ func NewAIProxy(cfg Config, dbEngine *engine.Engine) (*AIProxy, error) {
 	// Initialize clients if RAG is enabled
 	if cfg.RAGEnabled {
 		fastConfig := cfg.FastLLM
-		if fastConfig.BaseURL == "" {
+		if fastConfig.BaseURL == "" && fastConfig.Provider == "" {
 			fastConfig = cfg.LLM
 		}
-		if fastConfig.BaseURL == "" {
+		if fastConfig.BaseURL == "" && fastConfig.Provider == "" {
 			fastConfig = llm.DefaultConfig()
 		}
 		p.fastLLMClient = llm.NewClient(fastConfig)
@@ -86,7 +86,7 @@ func NewAIProxy(cfg Config, dbEngine *engine.Engine) (*AIProxy, error) {
 
 		if cfg.RAGUseHyDe {
 			mainConfig := cfg.LLM
-			if mainConfig.BaseURL == "" {
+			if mainConfig.BaseURL == "" && mainConfig.Provider == "" {
 				mainConfig = llm.DefaultConfig()
 			}
 			p.llmClient = llm.NewClient(mainConfig)

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -2,9 +2,13 @@ port: ":9092"
 target_url: "http://localhost:11434"
 
 # Configurazione Embedder (usa il tuo modello locale)
-embedder_type: "ollama_api"
-embedder_url: "http://localhost:11434/api/embeddings"
-embedder_model: "nomic-embed-text-v2-moe:latest"
+# embedder_type: "ollama_api"
+# embedder_url: "http://localhost:11434/api/embeddings"
+# embedder_model: "nomic-embed-text-v2-moe:latest"
+embedder_type: "gemini"
+embedder_url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent"
+embedder_model: "gemini-embedding-2"
+embedder_api_key: &gemini_api_key "{GEMINI_API_KEY}"
 embedder_timeout: 60s
 
 # RAG Automatico
@@ -70,13 +74,19 @@ cache_delete_threshold: 0.0 # 0.0 = Pulisci sempre se c'è anche solo 1 cancella
 
 # rewriter
 fast_llm:
-  base_url: "http://localhost:11434/v1"
-  model: "gemma4:latest"
+  # base_url: "http://localhost:11434/v1"
+  base_url: "https://generativelanguage.googleapis.com/v1beta/interactions"
+  # model: "gemma4:latest"
+  model: "gemini-3.5-flash"
+  api_key: *gemini_api_key
 
 # HyDe
 llm:
-  base_url: "http://localhost:11434/v1"
-  model: "gemma4:latest"
+  # base_url: "http://localhost:11434/v1"
+  base_url: "https://generativelanguage.googleapis.com/v1beta/interactions"
+  # model: "gemma4:latest"
+  model: "gemini-3.5-flash"
+  api_key: *gemini_api_key
 
 rag_system_prompt: |
   Sei un assistente tecnico esperto.

--- a/vectorizers.yaml
+++ b/vectorizers.yaml
@@ -6,7 +6,8 @@ vectorizers:
     schedule: "30s"
     source:
       type: "filesystem"
-      path: "/home/dash/Documenti/nvim comandi"
+      # path: "/home/dash/Documenti/nvim comandi"
+      path: "/Users/treav/Desktop/Repo/Tools/OSS/docs"
     include_patterns: ["*.md", "*.txt", "*.pdf", "*.docx"]
     exclude_patterns: ["draft_*"] # Ignora bozze
     index_config:
@@ -16,9 +17,13 @@ vectorizers:
       ef_construction: 200 # <--- Costruzione più lenta ma precisa
       text_language: "italian" # <--- Stemming italiano per la ricerca ibrida
     embedder:
-      type: "ollama_api"
-      url: "http://localhost:11434/api/embeddings"
-      model: "nomic-embed-text-v2-moe:latest"
+      # type: "ollama_api"
+      # url: "http://localhost:11434/api/embeddings"
+      # model: "nomic-embed-text-v2-moe:latest"
+      type: gemini
+      url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent"
+      model: gemini-embedding-2
+      api_key: &gemini_api_key "{GEMINI_API_KEY}"
     document_processor:
       chunking_strategy: "markdown" # <--- Rispetta la struttura MD
       chunk_size: 1000
@@ -35,8 +40,11 @@ vectorizers:
     graph_enabled: true
     graph_entity_extraction: true
     llm:
-      base_url: "http://localhost:11434/v1"
-      model: "gemma4:latest" # O llama3, mistral, gpt-4o-mini...
+      # base_url: "http://localhost:11434/v1"
+      base_url: "https://generativelanguage.googleapis.com/v1beta/interactions"
+      # model: "gemma4:latest" # O llama3, mistral, gpt-4o-mini...
+      model: "gemini-3.5-flash"
+      api_key: *gemini_api_key
       temperature: 0.0 # Meglio deterministico per estrarre dati
 
     # Esempio HuggingFace (Serverless Inference):
@@ -47,9 +55,12 @@ vectorizers:
     #   temperature: 0.0
 
     vision_llm:
-      base_url: "http://localhost:11434/v1"
+      # base_url: "http://localhost:11434/v1"
+      base_url: "https://generativelanguage.googleapis.com/v1beta/interactions"
       # IMPORTANTE: Devi aver scaricato questo modello su Ollama!
       # Consigliato: llama3.2-vision (piccolo e potente) o llava
-      model: "gemma4:latest"
+      # model: "gemma4:latest"
+      model: "gemini-3.5-flash"
+      api_key: *gemini_api_key
       temperature: 0.0
       max_tokens: 300 # Limitiamo la descrizione per non intasare l'embedding


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->
Added native Gemini support across LLMs, embeddings, proxy config, vectorizer config, and cognitive config.

---

### Core LLM
*   **`pkg/llm/gemini_client.go`:** Added `GeminiClient` implementing the shared `llm.Client` interface.
    *   Supports Gemini `generateContent` and `/v1beta/interactions`.
    *   Supports text chat, image chat, system prompts, temperature, max tokens, and API keys.
*   **`pkg/llm/client.go`:** Updated `NewClient` to select Gemini via provider: `gemini` or Gemini `base_url`.
*   **`pkg/llm/config.go`:** Documented Gemini as a supported provider.

---

### Embeddings
*   **`pkg/embeddings/gemini.go`:** Added `GeminiEmbedder` using Gemini `embedContent`.
    *   Supports `gemini-embedding-2`, `embedder_url`, `embedder_model`, and API key passing.
    *   Keeps existing Ollama/OpenAI embedders intact.

---

### Proxy Integration
*   **`pkg/proxy/config.go`:** Added `embedder_api_key`.
*   **`cmd/kektordb/main.go`:** Added proxy embedder switch support for `gemini`.
*   **`pkg/proxy/proxy.go`:** Adjusted LLM fallback logic so provider/default Gemini configs work without requiring an Ollama-style base URL.

---

### Vectorizer / Cognitive
*   **`internal/server/vectorizer_service.go`:** Added Gemini embedder support for vectorizers.
*   **`internal/server/cognitive_config.go`:** Added provider support in cognitive YAML LLM config and cleared old default placeholders when provider is set.

---

### Config Files
*   **`proxy.yaml`:** Active proxy embedder is now Gemini, with old Ollama embedder config preserved as comments.
*   **`proxy.yaml`:** `fast_llm` and `llm` now use Gemini interactions URL and `gemini-3.5-flash`.
*   **`vectorizers.yaml`:** Active vectorizer embedder is Gemini; old Ollama config is commented.
*   **`vectorizers.yaml`:** `llm` and `vision_llm` now use Gemini.
*   **`cognitive.yaml`:** Cognitive LLM now uses `provider: "gemini"`.

## Related Issue

<!-- Closes #123 or related to #456 -->

#1 

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `chore` — Maintenance, dependencies, CI
- [x] `test` — Adding or updating tests

## Breaking Changes

- [ ] Yes — **BREAKING** (describe below)
- [x] No

<!-- If yes, explain the change and migration path. -->

## Testing Done

<!-- How did you test this? What commands did you run? -->

<img width="1919" height="1007" alt="Screenshot 2026-07-05 at 11 20 45 PM" src="https://github.com/user-attachments/assets/6e57c1d1-b20e-48a0-a398-b170a31d60f1" />
<img width="1919" height="1007" alt="Screenshot 2026-07-05 at 11 20 50 PM" src="https://github.com/user-attachments/assets/0674bba1-4dda-4300-9b4d-312d7d3a4cb9" />
<img width="1919" height="1007" alt="Screenshot 2026-07-05 at 11 20 57 PM" src="https://github.com/user-attachments/assets/f6e76f04-6d91-45f4-98a6-be1adda2ebe6" />
<img width="1919" height="1007" alt="Screenshot 2026-07-05 at 11 21 07 PM" src="https://github.com/user-attachments/assets/232f3a26-1d0b-4a07-8122-e4372842a00b" />
<img width="959" height="406" alt="Screenshot 2026-07-05 at 11 44 02 PM" src="https://github.com/user-attachments/assets/53a04b8f-081e-4b49-a6f5-d6dd7dce3b68" />


## Checklist

- [ ] Code is formatted (`gofmt -l .` shows no changes)
- [ ] `go vet ./...` passes
- [x] `go test -race -short ./...` passes in Pure Go mode
- [x] `make test-rust` passes (if changes affect `native/compute/`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (if API or behavior change)
- [x] `make clean` run before final commit — no generated files included
- [ ] `go mod tidy` reports clean `go.mod` / `go.sum`
